### PR TITLE
Allow registration of endpoints with specific uuid

### DIFF
--- a/forwarder/forwarder/forwarder.py
+++ b/forwarder/forwarder/forwarder.py
@@ -188,7 +188,6 @@ class Forwarder(Process):
             # Task is now submitted. Tack a callback on that.
             fu.add_done_callback(partial(self.handle_app_update, task_id))
 
-
     def update_endpoint_metadata(self):
         """ Geo locate the endpoint and push as metadata into redis
         """

--- a/forwarder/forwarder/service.py
+++ b/forwarder/forwarder/service.py
@@ -25,7 +25,7 @@ def ping():
 
 
 @get('/map.json')
-def get_mao_json():
+def get_map_json():
     """ Paint a map of utilization
     """
     results = []
@@ -109,7 +109,6 @@ def register():
                          endpoint_id,
                          endpoint_addr=endpoint_details['endpoint_addr'],
                          logging_level=logging.DEBUG if request.app.debug else logging.INFO)
-
 
     connection_info = fw.connection_info
     ret_package = {'endpoint_id': endpoint_id}

--- a/models/utils.py
+++ b/models/utils.py
@@ -154,7 +154,6 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
     user_id = resolve_user(user_name)
 
     try:
-        result_eid = None
         conn, cur = get_db_connection()
         if endpoint_uuid:
             # Check if the endpoint id already exists
@@ -165,8 +164,10 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
                 # If it does, make sure the user owns it
                 if rows[0]['user_id'] == user_id:
                     result_eid = endpoint_uuid
-
-                return result_eid
+                    query = "UPDATE sites set endpoint_name = %s where endpoint_uuid = %s and user_id = %s"
+                    cur.execute(query, (endpoint_name, endpoint_uuid, user_id))
+                    conn.commit()
+                    return result_eid
         else:
             endpoint_uuid = str(uuid.uuid4())
 
@@ -174,7 +175,7 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
                 "values (%s, %s, %s, %s, %s, %s)"
         cur.execute(query, (user_id, '', description, 'OFFLINE', endpoint_name, endpoint_uuid))
         conn.commit()
-        result_eid = endpoint_uuid
+
     except Exception as e:
         print(e)
         app.logger.error(e)

--- a/models/utils.py
+++ b/models/utils.py
@@ -156,6 +156,9 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
     try:
         conn, cur = get_db_connection()
         if endpoint_uuid:
+            # Check it is a valid uuid
+            uuid.UUID(endpoint_uuid)
+
             # Check if the endpoint id already exists
             query = "SELECT * from sites where endpoint_uuid = %s"
             cur.execute(query, (endpoint_uuid, ))
@@ -168,6 +171,8 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
                     cur.execute(query, (endpoint_name, endpoint_uuid, user_id))
                     conn.commit()
                     return result_eid
+                else:
+                    return None
         else:
             endpoint_uuid = str(uuid.uuid4())
 

--- a/models/utils.py
+++ b/models/utils.py
@@ -154,19 +154,27 @@ def register_endpoint(user_name, endpoint_name, description, endpoint_uuid=None)
     user_id = resolve_user(user_name)
 
     try:
+        result_eid = None
         conn, cur = get_db_connection()
         if endpoint_uuid:
-            # Make sure it exists
-            query = "SELECT * from sites where user_id = %s and endpoint_uuid = %s"
-            cur.execute(query, (user_id, endpoint_uuid))
+            # Check if the endpoint id already exists
+            query = "SELECT * from sites where endpoint_uuid = %s"
+            cur.execute(query, (endpoint_uuid, ))
             rows = cur.fetchall()
             if len(rows) > 0:
-                return endpoint_uuid
-        endpoint_uuid = str(uuid.uuid4())
+                # If it does, make sure the user owns it
+                if rows[0]['user_id'] == user_id:
+                    result_eid = endpoint_uuid
+
+                return result_eid
+        else:
+            endpoint_uuid = str(uuid.uuid4())
+
         query = "INSERT INTO sites (user_id, name, description, status, endpoint_name, endpoint_uuid) " \
                 "values (%s, %s, %s, %s, %s, %s)"
         cur.execute(query, (user_id, '', description, 'OFFLINE', endpoint_name, endpoint_uuid))
         conn.commit()
+        result_eid = endpoint_uuid
     except Exception as e:
         print(e)
         app.logger.error(e)

--- a/routes/funcx.py
+++ b/routes/funcx.py
@@ -390,7 +390,6 @@ def register_endpoint_2(user_name):
         endpoint_ip_addr = request.environ['HTTP_X_FORWARDED_FOR']
     app.logger.debug(f"Registering endpoint IP address as: {endpoint_ip_addr}")
 
-    # TODO: We should handle keyError here
     try:
         app.logger.debug(request.json['endpoint_name'])
         endpoint_uuid = register_endpoint(user_name,
@@ -413,13 +412,18 @@ def register_endpoint_2(user_name):
         response = {'status': 'error',
                     'reason': f'Caught error while registering endpoint {e}'}
 
-    try:
-        response = register_with_hub(
-            "http://10.0.0.112:8080", endpoint_uuid, endpoint_ip_addr)
-    except Exception as e:
-        app.logger.debug("Caught error during forwarder initialization")
+    if not endpoint_uuid:
+        app.logger.debug("Failed to register endpoint. Invalid UUID")
         response = {'status': 'error',
-                    'reason': f'Failed during broker start {e}'}
+                    'reason': f'Failed to register endpoint. Invalid UUID.'}
+    else:
+        try:
+            response = register_with_hub(
+                "http://10.0.0.112:8080", endpoint_uuid, endpoint_ip_addr)
+        except Exception as e:
+            app.logger.debug("Caught error during forwarder initialization")
+            response = {'status': 'error',
+                        'reason': f'Failed during broker start {e}'}
 
     return jsonify(response)
 


### PR DESCRIPTION
This PR will allow users to start an endpoint with a specific uuid. This will enable us to reconnect endpoints with the same uuid when the forwarder fails so we don't need to keep updating use cases with new endpoint ids. Once re-registration of endpoints works, this won't be terribly important.