### PR TITLE
Web-side functionality to ingest functions to Globus Search

### DIFF
--- a/forwarder/forwarder/__init__.py
+++ b/forwarder/forwarder/__init__.py
@@ -2,7 +2,7 @@
 
 """
 import logging
-from forwarder.version import VERSION
+from forwarder.forwarder.version import VERSION
 from logging.handlers import RotatingFileHandler
 
 __author__ = "The funcX team"

--- a/forwarder/forwarder/__init__.py
+++ b/forwarder/forwarder/__init__.py
@@ -2,7 +2,7 @@
 
 """
 import logging
-from forwarder.forwarder.version import VERSION
+from forwarder.version import VERSION
 from logging.handlers import RotatingFileHandler
 
 __author__ = "The funcX team"

--- a/models/search.py
+++ b/models/search.py
@@ -40,6 +40,7 @@ def _trim_func_data(func_data):
     return {
         'function_name': func_data['function_name'],
         'function_code': func_data['function_code'],
+        'function_source': func_data['function_source'],
         'container_uuid': func_data.get('container_uuid', ''),
         'description': func_data['description'],
         'public': func_data['public'],

--- a/models/search.py
+++ b/models/search.py
@@ -1,0 +1,113 @@
+from flask import request
+from globus_sdk import AccessTokenAuthorizer, SearchClient, SearchAPIError
+
+from authentication.auth import get_auth_client
+
+SEARCH_INDEX_NAME = 'funcx'
+SEARCH_INDEX_ID = '673a4b58-3231-421d-9473-9df1b6fa3a9d'
+SEARCH_SCOPE = 'urn:globus:auth:scope:search.api.globus.org:all'
+
+# Search limit defined by the globus API
+SEARCH_LIMIT = 10000
+
+# By default we will return 10 functions at a time
+DEFAULT_SEARCH_LIMIT = 10
+
+
+def get_search_client():
+    """Creates a Globus Search Client using FuncX's client token"""
+    auth_client = get_auth_client()
+    tokens = auth_client.oauth2_client_credentials_tokens(requested_scopes=[SEARCH_SCOPE])
+    search_token = tokens.by_scopes[SEARCH_SCOPE]
+    authorizer = AccessTokenAuthorizer(search_token)
+    search_client = SearchClient(authorizer)
+    return search_client
+
+
+def _trim_func_data(func_data):
+    """Remove unnecessary fields from FuncX function metadata for ingest
+
+    Parameters
+    ----------
+    func_data : dict
+        the data put into redis for a function
+
+    Returns
+    -------
+    dict
+        a dict with the fields we want in search, notably including an author field
+    """
+    return {
+        'function_name': func_data['function_name'],
+        'function_code': func_data['function_code'],
+        'container_uuid': func_data.get('container_uuid', ''),
+        'description': func_data['description'],
+        'public': func_data['public'],
+        'group': func_data['group'],
+        'author': ''
+    }
+
+
+def _exists(client, func_uuid):
+    """Checks if a func_uuid exists in the search index
+
+    Mainly used to determine whether we need a create or an update call to the search API
+
+    Parameters
+    ----------
+    func_uuid : str
+        the uuid of the function
+
+    Returns
+    -------
+    bool
+        True if `func_uuid` is a subject in Globus Search index
+    """
+    try:
+        res = client.get_entry(SEARCH_INDEX_ID, func_uuid)
+        return len(res.data['entries']) > 0
+    except SearchAPIError as err:
+        if err.http_status == 404:
+            return False
+        raise err
+
+
+def ingest_or_update(func_uuid, func_data, author="", author_urn=""):
+    """Update or create a function in search index
+
+    Parameters
+    ----------
+    func_uuid : str
+    func_data : dict
+    author : str
+    author_urn : str
+    """
+    client = get_search_client()
+    acl = []
+    if func_data['public']:
+        acl.append('public')
+    elif func_data['group']:
+        acl.append(func_data['group'])
+
+    # Ensure that the author of the function and the funcx search admin group have access
+    # TODO: do we want access to everything? Is this the default since we control the index?
+    acl.append(author_urn)
+    acl.append('urn:globus:groups:id:69e12e30-b499-11ea-91c1-0a0ee5aecb35')
+
+    content = _trim_func_data(func_data)
+    content['author'] = author
+    content['version'] = '0'
+
+    ingest_data = {
+        'subject': func_uuid,
+        'visible_to': acl,
+        'content': content
+    }
+
+    # Since we associate only 1 entry with each subject (func_uuid), there is basically
+    # no difference between creating and updating, other than the method...
+
+    if not _exists(client, func_uuid):
+        client.create_entry(SEARCH_INDEX_ID, ingest_data)
+    else:
+        client.update_entry(SEARCH_INDEX_ID, ingest_data)

--- a/models/utils.py
+++ b/models/utils.py
@@ -231,7 +231,7 @@ def register_function(user_name, function_name, description, function_code, entr
     return function_uuid
 
 
-def ingest_function(user_name, user_uuid, func_uuid, function_name, description, function_code, entry_point, container_uuid, group, public):
+def ingest_function(user_name, user_uuid, func_uuid, function_name, description, function_code, function_source, entry_point, container_uuid, group, public):
     """Ingest a function into Globus Search
 
     Restructures data for ingest purposes.
@@ -243,6 +243,7 @@ def ingest_function(user_name, user_uuid, func_uuid, function_name, description,
     function_name : str
     description : str
     function_code : str
+    function_source : str
     entry_point : str
     container_uuid : str
     group : str
@@ -255,6 +256,7 @@ def ingest_function(user_name, user_uuid, func_uuid, function_name, description,
     data = {
         "function_name": function_name,
         "function_code": function_code,
+        "function_source": function_source,
         "container_uuid": container_uuid,
         "entry_point": entry_point,
         "description": description,

--- a/models/utils.py
+++ b/models/utils.py
@@ -8,6 +8,8 @@ import psycopg2.extras
 
 from flask import request, current_app as app
 from errors import *
+from models import search
+
 
 class db_invocation_logger(object):
 
@@ -227,6 +229,40 @@ def register_function(user_name, function_name, description, function_code, entr
         cur.execute(query, (group, function_uuid))
     conn.commit()
     return function_uuid
+
+
+def ingest_function(user_name, user_uuid, func_uuid, function_name, description, function_code, entry_point, container_uuid, group, public):
+    """Ingest a function into Globus Search
+
+    Restructures data for ingest purposes.
+
+    Parameters
+    ----------
+    user_name : str
+    user_uuid : str
+    function_name : str
+    description : str
+    function_code : str
+    entry_point : str
+    container_uuid : str
+    group : str
+    public : bool
+
+    Returns
+    -------
+    None
+    """
+    data = {
+        "function_name": function_name,
+        "function_code": function_code,
+        "container_uuid": container_uuid,
+        "entry_point": entry_point,
+        "description": description,
+        "public": public,
+        "group": group
+    }
+    user_urn = f"urn:globus:auth:identity:{user_uuid}"
+    search.ingest_or_update(func_uuid, data, author=user_name, author_urn=user_urn)
 
 
 def register_container(user_name, container_name, location, description, container_type):

--- a/routes/funcx.py
+++ b/routes/funcx.py
@@ -1,24 +1,20 @@
-import uuid
 import json
+import uuid
+
 import requests
-import time
-from requests.models import Response
-
-from version import VERSION
-from errors import *
-
-from models.utils import register_endpoint, register_function, get_container, resolve_user
-from models.utils import register_container, get_redis_client
-
-from models.utils import resolve_function, log_invocation, db_invocation_logger
-from models.utils import (update_function, delete_function, delete_endpoint, get_ep_whitelist,
-                         add_ep_whitelist, delete_ep_whitelist)
-
-from models.serializer import serialize_inputs, deserialize_result
-
-from authentication.auth import authorize_endpoint, authenticated, authorize_function
 from flask import current_app as app, Blueprint, jsonify, request, abort, send_from_directory, g
 
+from authentication.auth import authorize_endpoint, authenticated, authorize_function, authenticated_w_uuid
+from errors import *
+from forwarder.forwarder.errors import RegistrationError
+from models import search
+from models.serializer import serialize_inputs, deserialize_result
+from models.utils import register_container, get_redis_client
+from models.utils import register_endpoint, register_function, get_container, resolve_user, ingest_function
+from models.utils import resolve_function, db_invocation_logger
+from models.utils import (update_function, delete_function, delete_endpoint, get_ep_whitelist,
+                          add_ep_whitelist, delete_ep_whitelist)
+from version import VERSION
 from .redis_q import RedisQueue
 
 # Flask
@@ -897,8 +893,8 @@ def register_endpoint_2(user_name):
 
 
 @funcx_api.route("/register_function", methods=['POST'])
-@authenticated
-def reg_function(user_name):
+@authenticated_w_uuid
+def reg_function(user_name, user_uuid):
     """Register the function.
 
     Parameters
@@ -953,6 +949,19 @@ def reg_function(user_name):
         return jsonify({'status': 'Failed',
                         'reason': message})
 
+    try:
+        ingest_function(
+            user_name, user_uuid, function_uuid, function_name, description, function_code,
+            entry_point, container_uuid, group, public)
+    except Exception as e:
+        message = "Function ingest to search failed for user:{} function_name:{} due to {}".format(
+            user_name,
+            function_name,
+            e)
+        app.logger.error(message)
+        return jsonify({'status': 'Failed',
+                        'reason': message})
+
     return jsonify({'function_uuid': function_uuid})
 
 
@@ -982,6 +991,8 @@ def upd_function(user_name):
         function_code = request.json["code"]
         result = update_function(user_name, function_uuid, function_name,
                                  function_desc, function_entry_point, function_code)
+
+
         # app.logger.debug("[LOGGER] result: " + str(result))
         return jsonify({'result': result})
     except Exception as e:

--- a/routes/funcx.py
+++ b/routes/funcx.py
@@ -922,14 +922,15 @@ def reg_function(user_name, user_uuid):
         abort(400, description="Could not find user. You must be "
                                "logged in to perform this function.")
     try:
-
         function_name = request.json["function_name"]
         entry_point = request.json["entry_point"]
         description = request.json["description"]
         function_code = request.json["function_code"]
+        function_source = request.json.get("function_source", "")
         container_uuid = request.json.get("container_uuid", None)
         group = request.json.get("group", None)
         public = request.json.get("public", False)
+        searchable = request.json.get("searchable", True)
 
     except Exception as e:
         app.logger.error(e)
@@ -949,10 +950,13 @@ def reg_function(user_name, user_uuid):
         return jsonify({'status': 'Failed',
                         'reason': message})
 
+    response = jsonify({'function_uuid': function_uuid})
+    if not searchable:
+        return response
     try:
         ingest_function(
             user_name, user_uuid, function_uuid, function_name, description, function_code,
-            entry_point, container_uuid, group, public)
+            function_source, entry_point, container_uuid, group, public)
     except Exception as e:
         message = "Function ingest to search failed for user:{} function_name:{} due to {}".format(
             user_name,
@@ -962,7 +966,7 @@ def reg_function(user_name, user_uuid):
         return jsonify({'status': 'Failed',
                         'reason': message})
 
-    return jsonify({'function_uuid': function_uuid})
+    return response
 
 
 @funcx_api.route("/upd_function", methods=['POST'])

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export APP_SETTINGS=config.DevelopmentConfig
+python application.py


### PR DESCRIPTION
Created the `models/search.py` module to wrap the Globus SDK's search ingest interface.  

When creating an entry in the search index, we need to specify who the entry is visible to, which requires the UUID of the user registering the function.  This necessitated the creation of an additional authentication decorator.  

The `register_function` route now also sends function data to search module.  

To test things, I had to run the server locally for which I made the utility script that exports the correct environment variable, and runs the application.  This would not run until a malformed import was corrected in the forwarder.  