### PR TITLE
Improving web-side tracking of tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ venv/*
 web/*
 api/*
 .idea/*
+forwarder/.idea/*
+forwarder/.idea/forwarder.iml
+*.iml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -116,4 +119,3 @@ ENV/
 
 # emacs buffers
 \#*
-

--- a/forwarder/forwarder/forwarder.py
+++ b/forwarder/forwarder/forwarder.py
@@ -100,7 +100,6 @@ class Forwarder(Process):
 
         self.endpoint_addr = endpoint_addr
         self.task_q = task_q
-        # self.result_q = result_q
         self.heartbeat_threshold = heartbeat_threshold
         self.executor = executor
         self.endpoint_id = endpoint_id
@@ -288,7 +287,6 @@ def spawn_forwarder(address,
                     endpoint_addr=None,
                     executor=None,
                     task_q=None,
-                    result_q=None,
                     logging_level=logging.INFO):
     """ Spawns a forwarder and returns the forwarder process for tracking.
 
@@ -325,15 +323,9 @@ def spawn_forwarder(address,
     if not task_q:
         # task_q = RedisQueue('task_{}'.format(endpoint_id), redis_address)
         task_q = EndpointQueue(endpoint_id, redis_address)
-    if not result_q:
-        # result_q = RedisQueue('result_{}'.format(endpoint_id), redis_address)
-        # Change of design. We want all tasks to go to a results table and results_list queue
-        # This would allow any frontend service to access the results stream.
-        result_q = RedisQueue('results', redis_address)
 
     print("Logging_level: {}".format(logging_level))
     print("Task_q: {}".format(task_q))
-    print("Result_q: {}".format(result_q))
 
     if not executor:
         executor = HTEX(label='htex',
@@ -342,7 +334,7 @@ def spawn_forwarder(address,
                         endpoint_db=EndpointDB(redis_address),
                         endpoint_id=endpoint_id,
                         address=address)
-    fw = Forwarder(task_q, result_q, executor,
+    fw = Forwarder(task_q, executor,
                    endpoint_id,
                    endpoint_addr=endpoint_addr,
                    redis_address=redis_address,

--- a/forwarder/forwarder/forwarder.py
+++ b/forwarder/forwarder/forwarder.py
@@ -204,7 +204,7 @@ class Forwarder(Process):
 
             try:
                 logger.debug("Submitting task to executor")
-                fu = self.executor.submit(full_payload, task_id=task.task_id)
+                fu = self.executor.submit(full_payload, task_id=task.header)
                 t_fin = time.time()
                 print(f"*** FINISH {task.task_id} *** {t_fin}")
 

--- a/forwarder/forwarder/queues/redis/tasks.py
+++ b/forwarder/forwarder/queues/redis/tasks.py
@@ -1,0 +1,125 @@
+import json
+from enum import Enum
+
+from redis import StrictRedis
+
+
+class TaskState(Enum):
+    RECEIVED = "received"  # on receiving a task web-side
+    WAITING_FOR_EP = "waiting-for-ep"  # while waiting for ep to accept/be online
+    WAITING_FOR_NODES = "waiting-for-nodes"  # jobs are pending at the scheduler
+    WAITING_FOR_LAUNCH = "waiting-for-launch"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class Task:
+    """
+    ORM-esque class to wrap access to properties of tasks for better style and encapsulation
+
+    TODO: have a cache and TTL on the properties so that we aren't making so many redis gets?
+    """
+    def __init__(self, rc: StrictRedis, task_id: str, container: str = "", serializer: str = "", payload: str = ""):
+        """ If the kwargs are passed, then they will be overwritten.  Otherwise, they will gotten from existing
+        task entry.
+        Parameters
+        ----------
+        rc : StrictRedis
+            Redis client so that properties can get get/set
+        task_id : str
+            UUID of task
+        container : str
+            UUID of container in which to run
+        serializer : str
+        payload : str
+            serialized function + input data
+        """
+        self.rc = rc
+        self.task_id = task_id
+        self._task_hname = self._generate_hname(self.task_id)
+
+        # If passed, we assume they should be set (i.e. in cases of new tasks)
+        # if not passed,
+        if container:
+            self.container = container
+
+        if serializer:
+            self.serializer = serializer
+
+        if payload:
+            self.payload = payload
+
+        self.header = self._generate_header()
+
+    @staticmethod
+    def _generate_hname(task_id):
+        return f'task_{task_id}'
+
+    def _generate_header(self):
+        """Used to pass bits of information to EP"""
+        return f'{self.task_id};{self.container};{self.serializer}'
+
+    def _get(self, key):
+        """Get's the value of key via redis"""
+        return self.rc.hget(self._task_hname, key)
+
+    def _set(self, key, value):
+        """Sets key -> value in Redis"""
+        self.rc.hset(self._task_hname, key, value)
+
+    @property
+    def status(self) -> TaskState:
+        return TaskState(self._get('status'))
+
+    @status.setter
+    def status(self, s: TaskState):
+        self._set('status', s.value)
+
+    @property
+    def endpoint(self):
+        return self._get('endpoint')
+
+    @endpoint.setter
+    def endpoint(self, ep):
+        self._set('endpoint', ep)
+
+    @property
+    def container(self):
+        return self._get('container')
+
+    @container.setter
+    def container(self, c):
+        self._set('container', c)
+
+    @property
+    def payload(self):
+        return json.loads(self._get('payload'))
+
+    @payload.setter
+    def payload(self, p):
+        self._set('payload', json.dumps(p))
+
+    @property
+    def result(self):
+        r = self._get('result')
+        if r:
+            r = json.loads(r)
+        return r
+
+    @result.setter
+    def result(self, r):
+        self._set('result', json.dumps(r))
+
+    @classmethod
+    def exists(cls, rc: StrictRedis, task_id: str):
+        task_hname = cls._generate_hname(task_id)
+        return rc.exists(task_hname)
+
+    @classmethod
+    def from_id(cls, rc, task_id):
+        return cls(rc, task_id)
+
+    def delete(self):
+        """Removes this task from Redis, to be used after the result is gotten"""
+        self.rc.delete(self._task_hname)

--- a/forwarder/forwarder/queues/redis/tasks.py
+++ b/forwarder/forwarder/queues/redis/tasks.py
@@ -70,6 +70,7 @@ class Task:
 
     @property
     def status(self) -> TaskState:
+        """Get or set status in Redis"""
         return TaskState(self._get('status'))
 
     @status.setter
@@ -78,6 +79,7 @@ class Task:
 
     @property
     def endpoint(self):
+        """Get or set endpoint id in Redis"""
         return self._get('endpoint')
 
     @endpoint.setter
@@ -86,6 +88,7 @@ class Task:
 
     @property
     def container(self):
+        """Get or set container id in Redis"""
         return self._get('container')
 
     @container.setter
@@ -94,6 +97,7 @@ class Task:
 
     @property
     def payload(self):
+        """Get or set payload object in Redis (automatically json.loads or json.dumps)"""
         return json.loads(self._get('payload'))
 
     @payload.setter
@@ -102,6 +106,7 @@ class Task:
 
     @property
     def result(self):
+        """Get or set result object in Redis (automatically json.loads or json.dumps)"""
         r = self._get('result')
         if r:
             r = json.loads(r)
@@ -113,11 +118,13 @@ class Task:
 
     @classmethod
     def exists(cls, rc: StrictRedis, task_id: str):
+        """Check if a given task_id exists in Redis"""
         task_hname = cls._generate_hname(task_id)
         return rc.exists(task_hname)
 
     @classmethod
-    def from_id(cls, rc, task_id):
+    def from_id(cls, rc: StrictRedis, task_id: str):
+        """For more readable code, use this to find a task by id, using the redis client"""
         return cls(rc, task_id)
 
     def delete(self):

--- a/models/tasks.py
+++ b/models/tasks.py
@@ -1,0 +1,54 @@
+from enum import Enum
+
+from redis import StrictRedis
+
+
+class TaskState(Enum):
+    RECEIVED = "received"  # on receiving a task web-side
+    WAITING_FOR_EP = "waiting-for-ep"  # while waiting for ep to accept/be online
+    WAITING_FOR_NODES = "waiting-for-nodes"  # jobs are pending at the scheduler
+    WAITING_FOR_LAUNCH = "waiting-for-launch"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class Task:
+    """
+    ORM-esque class to wrap access to properties of tasks for better style and encapsulation
+    """
+    def __init__(self, rc: StrictRedis, task_id: str, container: str, serializer: str, payload: str):
+        """
+
+        Parameters
+        ----------
+        rc : StrictRedis
+            Redis client so that properties can get get/set
+        task_id : str
+            UUID of task
+        container : str
+            UUID of container in which to run
+        serializer : str
+        payload : str
+            serialized function + input data
+        """
+        self.rc = rc
+        self.task_id = task_id
+        self._task_hname = f'task_{self.task_id}'
+        self.container = container
+        self.serializer = serializer
+        self.payload = payload
+
+        self._task_header = self._generate_header()
+
+    def _generate_header(self):
+        """Used to pass bits of information to EP"""
+        return f'{self.task_id};{self.container};{self.serializer}'
+
+    @property
+    def status(self) -> TaskState:
+        return TaskState(self.rc.hget(self._task_hname, 'status'))
+
+    @status.setter
+    def status(self, s: TaskState):
+        self.rc.hset(self._task_hname, 'status', s.value)

--- a/models/tasks.py
+++ b/models/tasks.py
@@ -70,6 +70,7 @@ class Task:
 
     @property
     def status(self) -> TaskState:
+        """Get or set status in Redis"""
         return TaskState(self._get('status'))
 
     @status.setter
@@ -78,6 +79,7 @@ class Task:
 
     @property
     def endpoint(self):
+        """Get or set endpoint id in Redis"""
         return self._get('endpoint')
 
     @endpoint.setter
@@ -86,6 +88,7 @@ class Task:
 
     @property
     def container(self):
+        """Get or set container id in Redis"""
         return self._get('container')
 
     @container.setter
@@ -94,6 +97,7 @@ class Task:
 
     @property
     def payload(self):
+        """Get or set payload object in Redis (automatically json.loads or json.dumps)"""
         return json.loads(self._get('payload'))
 
     @payload.setter
@@ -102,6 +106,7 @@ class Task:
 
     @property
     def result(self):
+        """Get or set result object in Redis (automatically json.loads or json.dumps)"""
         r = self._get('result')
         if r:
             r = json.loads(r)
@@ -113,11 +118,13 @@ class Task:
 
     @classmethod
     def exists(cls, rc: StrictRedis, task_id: str):
+        """Check if a given task_id exists in Redis"""
         task_hname = cls._generate_hname(task_id)
         return rc.exists(task_hname)
 
     @classmethod
-    def from_id(cls, rc, task_id):
+    def from_id(cls, rc: StrictRedis, task_id: str):
+        """For more readable code, use this to find a task by id, using the redis client"""
         return cls(rc, task_id)
 
     def delete(self):

--- a/models/tasks.py
+++ b/models/tasks.py
@@ -17,9 +17,9 @@ class Task:
     """
     ORM-esque class to wrap access to properties of tasks for better style and encapsulation
     """
-    def __init__(self, rc: StrictRedis, task_id: str, container: str, serializer: str, payload: str):
-        """
-
+    def __init__(self, rc: StrictRedis, task_id: str, container: str = "", serializer: str = "", payload: str = ""):
+        """ If the kwargs are passed, then they will be overwritten.  Otherwise, they will gotten from existing
+        task entry.
         Parameters
         ----------
         rc : StrictRedis
@@ -34,21 +34,66 @@ class Task:
         """
         self.rc = rc
         self.task_id = task_id
-        self._task_hname = f'task_{self.task_id}'
-        self.container = container
-        self.serializer = serializer
-        self.payload = payload
+        self._task_hname = self._generate_hname(self.task_id)
 
-        self._task_header = self._generate_header()
+        # If passed, we assume they should be set (i.e. in cases of new tasks)
+        # if not passed,
+        if container:
+            self.container = container
+
+        if serializer:
+            self.serializer = serializer
+
+        if payload:
+            self.payload = payload
+
+        self.header = self._generate_header()
+
+    @staticmethod
+    def _generate_hname(task_id):
+        return f'task_{task_id}'
 
     def _generate_header(self):
         """Used to pass bits of information to EP"""
         return f'{self.task_id};{self.container};{self.serializer}'
 
+    def _get(self, key):
+        """Get's the value of key via redis"""
+        return self.rc.hget(self._task_hname, key)
+
+    def _set(self, key, value):
+        """Sets key -> value in Redis"""
+        self.rc.hset(self._task_hname, key, value)
+
     @property
     def status(self) -> TaskState:
-        return TaskState(self.rc.hget(self._task_hname, 'status'))
+        return TaskState(self._get('status'))
 
     @status.setter
     def status(self, s: TaskState):
-        self.rc.hset(self._task_hname, 'status', s.value)
+        self._set('status', s.value)
+
+    @property
+    def endpoint(self):
+        return self._get('endpoint')
+
+    @endpoint.setter
+    def endpoint(self, ep):
+        self._set('endpoint', ep)
+
+    @property
+    def container(self):
+        return self._get('container')
+
+    @container.setter
+    def container(self, c):
+        self._set('container', c)
+
+    @classmethod
+    def exists(cls, rc: StrictRedis, task_id: str):
+        task_hname = cls._generate_hname(task_id)
+        return rc.exists(task_hname)
+
+    @classmethod
+    def from_id(cls, rc, task_id):
+        return cls(rc, task_id)

--- a/models/tasks.py
+++ b/models/tasks.py
@@ -4,7 +4,8 @@ from enum import Enum
 from redis import StrictRedis
 
 
-class TaskState(Enum):
+# We subclass from str so that the enum can be JSON-encoded without adjustment
+class TaskState(str, Enum):
     RECEIVED = "received"  # on receiving a task web-side
     WAITING_FOR_EP = "waiting-for-ep"  # while waiting for ep to accept/be online
     WAITING_FOR_NODES = "waiting-for-nodes"  # jobs are pending at the scheduler

--- a/routes/funcx.py
+++ b/routes/funcx.py
@@ -113,11 +113,9 @@ def auth_and_launch(user_id, function_uuid, endpoints, input_data, app, token, s
         # At this point the packed function body and the args are concatable strings
         payload = fn_code + input_data
         task_id = str(uuid.uuid4())
-        # header = f"{task_id};{container_uuid};{serializer}"
         task = Task(rc, task_id, container_uuid, serializer, payload)
 
         for ep in endpoints:
-            # ep_queue[ep].put(header, 'task', payload)
             ep_queue[ep].enqueue(task)
             app.logger.debug(f"Task:{task_id} placed on queue for endpoint:{ep}")
 


### PR DESCRIPTION
In order to better track tasks, we need several things.  One is an ORM-esque (without the R) model to access any task-related information for better style, encapsulation, and less duplicated code.  

We defined several states which we might want to observe for Tasks, that can be found in `tasks.TaskState`.  Of these, only some can be entirely determined on the web-side, namely, `RECEIVED` and `WAITING_FOR_EP`.  `RECEIVED` is set during task submission, and `WAITING_FOR_EP` is set by the forwarder, while waiting for endpoint to connect, and then to accept the task.

On receipt of a result dict from the executor, the forwarder can also update the task status to be `FAILED` or `SUCCESS`.

The other states will require adding code at the endpoint, and perhaps sending updates for each task along with the heartbeats.  