### PR TITLE
Batch status and backwards compatibility for status

### DIFF
--- a/routes/funcx.py
+++ b/routes/funcx.py
@@ -287,7 +287,7 @@ def get_tasks_from_redis(task_ids):
         }
 
         # Note: this is for backwards compat, when we can't include a None result and have a
-        # non-complete status, we must forego the result field if task not complete.
+        # non-complete status, we must forgo the result field if task not complete.
         if not task_result:
             del all_tasks[task_id]['result']
     return all_tasks
@@ -326,14 +326,22 @@ def status_and_result(user_name, task_id):
         task.delete()
 
     deserialize = request.args.get("deserialize", False)
-    if deserialize:
+    if deserialize and task_result:
         task_result = deserialize_result(task_result)
 
+    # TODO: change client to have better naming conventions
+    # these fields like 'status' should be changed to 'task_status', because 'status' is normally
+    # used for HTTP codes.
     response = {
         'task_id': task_id,
-        'task_status': task_status,
-        'task_result': task_result
+        'status': task_status,
+        'result': task_result
     }
+
+    # Note: this is for backwards compat, when we can't include a None result and have a
+    # non-complete status, we must forgo the result field if task not complete.
+    if task_result is None:
+        del response['result']
 
     return jsonify(response)
 


### PR DESCRIPTION
I neglected the batch status route when I updated the Task interface.  I also needed to provide backwards compatibility so that the client can at least not error.  The client only will display pending or completed/failed, because it ignores the actual status passed back by the web server.  It only checks the existence of the result field, so I removed this when the result is not there (previously it was None).  