### PR TITLE
More version checking

### DIFF
--- a/forwarder/forwarder/service.py
+++ b/forwarder/forwarder/service.py
@@ -11,9 +11,10 @@ import logging
 import redis
 import threading
 
-from flask import Flask
+from flask import Flask, jsonify
 from flask import request
 
+from forwarder.version import VERSION, MIN_EP_VERSION
 from forwarder.forwarderobject import spawn_forwarder
 
 
@@ -25,6 +26,14 @@ def ping():
     """ Minimal liveness response
     """
     return "pong"
+
+
+@app.route('/version')
+def version():
+    return jsonify({
+        "forwarder": VERSION,
+        "min_ep_version": MIN_EP_VERSION
+    })
 
 
 @app.route('/map.json', methods=['GET'])

--- a/forwarder/forwarder/version.py
+++ b/forwarder/forwarder/version.py
@@ -3,4 +3,5 @@
 <Major>.<Minor>.<maintenance>[alpha/beta/..]
 Alphas will be numbered like this -> 0.4.0a0
 """
-VERSION = '0.0.1'
+VERSION = '0.0.2'
+MIN_EP_VERSION = '0.0.1a7'


### PR DESCRIPTION
Adding forwarder version route, forwarder maintains minimum endpoint version, and main /version route returns more detailed info if passed URL parameter.  

This addresses [#197](https://github.com/funcx-faas/funcX/issues/197) from the funcx repo.  