### PR TITLE
Upgrade cryptography package to remove vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi==1.14.0
 chardet==3.0.4
 click==7.1.2
 configobj==5.0.6
-cryptography==2.9.2
+cryptography>=3.2
 decorator==4.4.2
 defusedxml==0.6.0
 dill==0.3.2


### PR DESCRIPTION
# Problem
`safety` check flagged a vulnerability in cryptography library versions prior to 3.2

# Approach
Updated requirements.txt