### PR TITLE
Issue 195 scope client config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,10 @@ jobs:
     - name: Check for vulnerabilities in libraries
       run: |
         pip install safety
-        pip freeze | safety check
+        # The `-i 41002` can be removed when
+        # https://github.com/pyupio/safety-db/issues/2335
+        # is resolved
+        pip freeze | safety check -i 41002
     - name: Test with pytest
       run: |
         python -m coverage run -m pytest -r sx tests/

--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -13,6 +13,9 @@ from globus_sdk.base import BaseClient
 from functools import wraps
 from flask import abort
 
+# Default scope if not provided in config
+FUNCX_SCOPE = 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all'
+
 
 def authenticated(f):
     """Decorator for globus auth."""
@@ -71,6 +74,7 @@ def authenticated_w_uuid(f):
         return f(user_rec, user_uuid, *args, **kwargs)
     return decorated_function
 
+
 def verify_auth_detail(auth_detail):
     """Validate auth introspect response and ensure token is active and has
     proper scopes.
@@ -83,7 +87,7 @@ def verify_auth_detail(auth_detail):
     if not auth_detail.get('active', False):
         abort(401, 'Credentials are inactive.')
 
-    if not app.config['FUNCX_SCOPE'] in auth_detail['scope']:
+    if not app.config.get('FUNCX_SCOPE', FUNCX_SCOPE) in auth_detail['scope']:
         abort(403, 'Missing Scopes')
 
 

--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -111,9 +111,11 @@ def check_group_membership(token, endpoint_groups):
     dep_tokens = client.oauth2_get_dependent_tokens(token)
 
     if "groups.api.globus.org" in dep_tokens.by_resource_server:
+        app.logger.debug("Using groups v2 api.")
         token = dep_tokens.by_resource_server["groups.api.globus.org"]["access_token"]
         user_group_ids = _get_group_ids_groups_api(token)
     else:
+        app.logger.debug("Using legacy nexus api.")
         token = dep_tokens.by_resource_server["nexus.api.globus.org"]["access_token"]
         user_group_ids = _get_group_ids_nexus_api(token)
 

--- a/funcx_web_service/routes/auth.py
+++ b/funcx_web_service/routes/auth.py
@@ -3,7 +3,7 @@ from funcx_web_service.models.user import User
 from flask import request, flash, redirect, session, url_for, Blueprint, current_app as app
 
 auth_api = Blueprint("auth_api", __name__)
-FUNCX_SCOPE = 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all'
+
 
 @auth_api.route('/login', methods=['GET'])
 def login():

--- a/funcx_web_service/routes/auth.py
+++ b/funcx_web_service/routes/auth.py
@@ -24,7 +24,7 @@ def callback():
     # Set up our Globus Auth/OAuth2 state
     redirect_uri = f"{app.config['HOSTNAME']}/callback"
     client = get_auth_client()
-    requested_scopes = ['https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all', 'profile',
+    requested_scopes = [app.config['FUNCX_SCOPE'], 'profile',
                         'urn:globus:auth:scope:transfer.api.globus.org:all',
                         'urn:globus:auth:scope:auth.globus.org:view_identities', 'openid']
     client.oauth2_start_flow(redirect_uri, requested_scopes=requested_scopes, refresh_tokens=False)

--- a/funcx_web_service/routes/auth.py
+++ b/funcx_web_service/routes/auth.py
@@ -1,9 +1,9 @@
-from funcx_web_service.authentication.auth import get_auth_client
+from funcx_web_service.authentication.auth import get_auth_client, FUNCX_SCOPE
 from funcx_web_service.models.user import User
 from flask import request, flash, redirect, session, url_for, Blueprint, current_app as app
 
 auth_api = Blueprint("auth_api", __name__)
-
+FUNCX_SCOPE = 'https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all'
 
 @auth_api.route('/login', methods=['GET'])
 def login():
@@ -24,7 +24,7 @@ def callback():
     # Set up our Globus Auth/OAuth2 state
     redirect_uri = f"{app.config['HOSTNAME']}/callback"
     client = get_auth_client()
-    requested_scopes = [app.config['FUNCX_SCOPE'], 'profile',
+    requested_scopes = [app.config.get('FUNCX_SCOPE', FUNCX_SCOPE), 'profile',
                         'urn:globus:auth:scope:transfer.api.globus.org:all',
                         'urn:globus:auth:scope:auth.globus.org:view_identities', 'openid']
     client.oauth2_start_flow(redirect_uri, requested_scopes=requested_scopes, refresh_tokens=False)

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -37,7 +37,9 @@ def mock_auth_client(mocker, mock_user):
     mock_auth_client.oauth2_token_introspect = mocker.Mock(
         return_value={
             "username": "bob",
-            "sub": "123-456"
+            "sub": "123-456",
+            "active": True,
+            "scope": "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
         })
 
     mocker.patch.object(funcx_web_service.authentication.auth, "get_auth_client",


### PR DESCRIPTION
This addresses the web service side of #195.  The critical bit just exposes an app config field to set the scope.  However, while I was in there I tackled a few other minor but releated things:

* Since a major part of the purpose of this effort was to make creating your own scope/client easy (or at least easier) and currently to create a scope that has a static dependency on the nexus api you need the Globus Auth teams involvment and blessing, I figured it would be easier to change that dependency to use the generally available groups v2 api.  The change should be backward compatible and deployed as is it should be able to continue accepting tokens that are only granted the nexus dependency, but we should consider a timeline for updating the prod client/scope to request the groups v2 dependent scope.
