### PR TITLE
Reject endpoint registration by non-owner and respond with correct errors

### DIFF
--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -220,7 +220,7 @@ def register_endpoint(user: User, endpoint_name, description, endpoint_uuid=None
             else:
                 app.logger.debug(f"Endpoint {endpoint_uuid} was previously registered "
                                  f"with user {existing_endpoint.user_id} not {user_id}")
-                return None
+                raise Exception(f"Endpoint {endpoint_uuid} was already registered by a different user")
     else:
         endpoint_uuid = str(uuid.uuid4())
     try:


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcx-web-service/issues/187

Rather than returning a UUID of `None` when an endpoint uuid is already owned by another user, it now throws an error.

I also realized that error response messages were getting thrown away when they shouldn't during registration. This is because even if an error occurred, the handler would try to call `register_with_hub` anyway. I have fixed this by checking if the `response` variable has been set, and only attempting to do `register_with_hub` if it has not already been set by an error occurrence