### PR TITLE
Fix endpoint/function authorization handling

### DIFF
--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -2,6 +2,7 @@ from funcx_web_service.models.auth_groups import AuthGroup
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.user import User
 from funcx_web_service.models.function import Function, FunctionAuthGroup
+from funcx_web_service.errors import FunctionNotFound, EndpointNotFound, FunctionNotPermitted
 from flask import request, current_app as app
 import functools
 
@@ -134,15 +135,14 @@ def authorize_endpoint(user_id, endpoint_uuid, function_uuid, token):
     authorized = False
 
     if not endpoint:
-        raise Exception(
-            f"Endpoint {endpoint_uuid} not found")
+        raise EndpointNotFound(endpoint_uuid)
 
     if endpoint.restricted:
         app.logger.debug("Restricted endpoint, checking function is allowed.")
         whitelisted_functions = [f.function_uuid for f in endpoint.restricted_functions]
 
         if function_uuid not in whitelisted_functions:
-            raise Exception(f"Function {function_uuid} not permitted on endpoint {endpoint_uuid}")
+            raise FunctionNotPermitted(function_uuid, endpoint_uuid)
 
     if endpoint.public:
         authorized = True
@@ -187,8 +187,7 @@ def authorize_function(user_id, function_uuid, token):
     function = Function.find_by_uuid(function_uuid)
 
     if not function:
-        raise Exception(
-            f"Function {function_uuid} not found")
+        raise FunctionNotFound(function_uuid)
 
     if function.user_id == user_id:
         authorized = True

--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -109,6 +109,9 @@ def authorize_endpoint(user_id, endpoint_uuid, function_uuid, token):
     check if there are any groups associated with the endpoint and determine if the user
     is a member of any of them.
 
+    Raises an Exception if the endpoint does not exist, or if the endpoint is
+    restricted and the provided function is not whitelisted.
+
     Parameters
     ----------
     user_id : str
@@ -162,6 +165,8 @@ def authorize_function(user_id, function_uuid, token):
     This is done in two steps: first, check if the user owns the function. If not,
     check if there are any groups associated with the function and determine if the user
     is a member of any of them.
+
+    Raises an Exception if the function does not exist.
 
     Parameters
     ----------

--- a/funcx_web_service/errors.py
+++ b/funcx_web_service/errors.py
@@ -1,5 +1,5 @@
 class FuncxError(Exception):
-    """ Base class for all Forwarder exceptions
+    """ Base class for all web service exceptions
     """
 
     def __init__(self, reason):
@@ -10,16 +10,55 @@ class FuncxError(Exception):
 
 
 class UserNotFound(FuncxError):
-    """ Base class for all Forwarder exceptions
+    """ User not found exception
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+    
+    def __repr__(self):
+        return self.reason
+
+
+class FunctionNotFound(FuncxError):
+    """ Function could not be resolved from the database
+    """
+    def __init__(self, uuid):
+        self.reason = "Function {} could not be resolved".format(uuid)
+        self.uuid = uuid
+    
+    def __repr__(self):
+        return self.reason
+
+
+class EndpointNotFound(FuncxError):
+    """ Endpoint could not be resolved from the database
+    """
+    def __init__(self, uuid):
+        self.reason = "Endpoint {} could not be resolved".format(uuid)
+        self.uuid = uuid
+
+    def __repr__(self):
+        return self.reason
+
+
+class FunctionNotPermitted(FuncxError):
+    """ Function not permitted on endpoint
+    """
+    def __init__(self, function_uuid, endpoint_uuid):
+        self.reason = "Function {} not permitted on endpoint {}".format(function_uuid, endpoint_uuid)
+        self.function_uuid = function_uuid
+        self.endpoint_uuid = endpoint_uuid
+
+    def __repr__(self):
+        return self.reason
+
+class ForwarderRegistrationError(FuncxError):
+    """ Registering the endpoint with the forwarder has failed
     """
 
     def __init__(self, reason):
         self.reason = reason
 
-
-class MissingFunction(FuncxError):
-    """ Function could not be resolved from the database
-    """
-    def __init__(self, uuid):
-        self.reason = "FunctionID {} could not be resolved".format(uuid)
-        self.uuid = uuid
+    def __repr__(self):
+        return "Endpoint registration with forwarder failed due to {}".format(self.reason)

--- a/funcx_web_service/errors.py
+++ b/funcx_web_service/errors.py
@@ -15,7 +15,7 @@ class UserNotFound(FuncxError):
 
     def __init__(self, reason):
         self.reason = reason
-    
+
     def __repr__(self):
         return self.reason
 
@@ -26,7 +26,7 @@ class FunctionNotFound(FuncxError):
     def __init__(self, uuid):
         self.reason = "Function {} could not be resolved".format(uuid)
         self.uuid = uuid
-    
+
     def __repr__(self):
         return self.reason
 
@@ -52,6 +52,7 @@ class FunctionNotPermitted(FuncxError):
 
     def __repr__(self):
         return self.reason
+
 
 class ForwarderRegistrationError(FuncxError):
     """ Registering the endpoint with the forwarder has failed

--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -5,7 +5,7 @@ import redis
 from flask import current_app as app
 
 from funcx_web_service.models import search
-from funcx_web_service.errors import MissingFunction
+from funcx_web_service.errors import FunctionNotFound
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.tasks import DBTask
@@ -262,7 +262,7 @@ def resolve_function(user_id, function_uuid):
     saved_function = Function.find_by_uuid(function_uuid)
 
     if not saved_function:
-        raise MissingFunction(function_uuid)
+        raise FunctionNotFound(function_uuid)
 
     function_code = saved_function.function_source_code
     function_entry = saved_function.entry_point

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -84,7 +84,6 @@ def auth_and_launch(user_id, function_uuid, endpoints, input_data, app, token, s
             return {'status': 'Failed',
                     'reason': f'Unauthorized access to function: {function_uuid}'}
     except Exception as e:
-        print(e)
         return {'status': 'Failed',
                 'reason': f'Function authorization failed. {str(e)}'}
 

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -98,7 +98,7 @@ def auth_and_launch(user_id, function_uuid, endpoints, input_data, app, token, s
         try:
             if not authorize_endpoint(user_id, ep, function_uuid, token):
                 return {'status': 'Failed',
-                        'reason': f'Unauthorized access to endpoint: {ep}'}    
+                        'reason': f'Unauthorized access to endpoint: {ep}'}
         except Exception as e:
             return {'status': 'Failed',
                     'reason': f'Endpoint authorization failed for endpoint {ep}. {e}'}


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcx-web-service/issues/200 and https://github.com/funcx-faas/funcX/issues/329

The authorization functions needed some better descriptions for when they raise exceptions. Calls to these functions needed exception handlers. The output for a bad endpoint now looks like this:

![endpoint-fail](https://user-images.githubusercontent.com/22580625/106225291-75958580-61aa-11eb-85ef-138937d6a82d.png)
