### PR TITLE
Refactor service response errors

### DIFF
--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -2,6 +2,7 @@ from funcx_web_service.models.auth_groups import AuthGroup
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.user import User
 from funcx_web_service.models.function import Function, FunctionAuthGroup
+from funcx_web_service.errors import FunctionNotFound, EndpointNotFound, FunctionNotPermitted
 from flask import request, current_app as app
 import functools
 
@@ -134,15 +135,14 @@ def authorize_endpoint(user_id, endpoint_uuid, function_uuid, token):
     authorized = False
 
     if not endpoint:
-        raise Exception(
-            f"Endpoint {endpoint_uuid} not found")
+        raise EndpointNotFound(endpoint_uuid)
 
     if endpoint.restricted:
         app.logger.debug("Restricted endpoint, checking function is allowed.")
         whitelisted_functions = [f.function_uuid for f in endpoint.restricted_functions]
 
         if function_uuid not in whitelisted_functions:
-            raise Exception(f"Function {function_uuid} not permitted on endpoint {endpoint_uuid}")
+            raise FunctionNotPermitted(function_uuid, endpoint_uuid)
 
     if endpoint.public:
         authorized = True
@@ -187,8 +187,7 @@ def authorize_function(user_id, function_uuid, token):
     function = Function.find_by_uuid(function_uuid)
 
     if not function:
-        raise Exception(
-            f"Function {function_uuid} not found")
+        raise FunctionNotFound(function_uuid)
 
     if function.user_id == user_id:
         authorized = True

--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -2,7 +2,7 @@ from funcx_web_service.models.auth_groups import AuthGroup
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.user import User
 from funcx_web_service.models.function import Function, FunctionAuthGroup
-from funcx_web_service.errors import FunctionNotFound, EndpointNotFound, FunctionNotPermitted
+from funcx.utils.response_errors import FunctionNotFound, EndpointNotFound, FunctionNotPermitted
 from flask import request, current_app as app
 import functools
 

--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -109,6 +109,9 @@ def authorize_endpoint(user_id, endpoint_uuid, function_uuid, token):
     check if there are any groups associated with the endpoint and determine if the user
     is a member of any of them.
 
+    Raises an Exception if the endpoint does not exist, or if the endpoint is
+    restricted and the provided function is not whitelisted.
+
     Parameters
     ----------
     user_id : str
@@ -162,6 +165,8 @@ def authorize_function(user_id, function_uuid, token):
     This is done in two steps: first, check if the user owns the function. If not,
     check if there are any groups associated with the function and determine if the user
     is a member of any of them.
+
+    Raises an Exception if the function does not exist.
 
     Parameters
     ----------

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -1,0 +1,20 @@
+from funcx.utils.response_errors import FuncxResponseError
+from flask import current_app as jsonify
+
+def create_error_response(exception, as_json=False):
+
+    if isinstance(exception, FuncxResponseError):
+        response = {'status': 'Failed',
+                    'code': exception.code,
+                    'error_args': exception.error_args,
+                    'reason': exception.reason}
+    else:
+        response = {'status': 'Failed',
+                    'code': 0,
+                    'error_args': [],
+                    'reason': f'An unknown error occurred: {exception}'}
+
+    if as_json:
+        return jsonify(response)
+    
+    return response

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -1,20 +1,13 @@
 from funcx.utils.response_errors import FuncxResponseError
-from flask import current_app as jsonify
 
-def create_error_response(exception, as_json=False):
+def create_error_response(exception):
 
     if isinstance(exception, FuncxResponseError):
-        response = {'status': 'Failed',
-                    'code': exception.code,
-                    'error_args': exception.error_args,
-                    'reason': exception.reason}
+        response = exception.pack()
     else:
         response = {'status': 'Failed',
                     'code': 0,
                     'error_args': [],
                     'reason': f'An unknown error occurred: {exception}'}
-
-    if as_json:
-        return jsonify(response)
     
     return response

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -1,13 +1,20 @@
+from flask import jsonify
+
 from funcx.utils.response_errors import FuncxResponseError
 
-def create_error_response(exception):
+def create_error_response(exception, jsonify_response=False):
 
     if isinstance(exception, FuncxResponseError):
         response = exception.pack()
+        status_code = int(exception.http_status_code)
     else:
         response = {'status': 'Failed',
                     'code': 0,
                     'error_args': [],
                     'reason': f'An unknown error occurred: {exception}'}
+        status_code = 500
     
-    return response
+    if jsonify_response:
+        response = jsonify(response)
+
+    return response, status_code

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -2,9 +2,11 @@ from flask import jsonify
 
 from funcx.utils.response_errors import FuncxResponseError
 
-def create_error_response(exception, jsonify_response=False):
 
+def create_error_response(exception, jsonify_response=False):
     if isinstance(exception, FuncxResponseError):
+        # the pack method turns a FuncxResponseError into a record
+        # which will become json
         response = exception.pack()
         status_code = int(exception.http_status_code)
     else:
@@ -13,7 +15,7 @@ def create_error_response(exception, jsonify_response=False):
                     'error_args': [],
                     'reason': f'An unknown error occurred: {exception}'}
         status_code = 500
-    
+
     if jsonify_response:
         response = jsonify(response)
 

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -4,12 +4,34 @@ from funcx.utils.response_errors import FuncxResponseError
 
 
 def create_error_response(exception, jsonify_response=False):
+    """ Creates JSON object responses for errors that occur in the service.
+    These responses can be sent back to the funcx SDK client to be decoded.
+    They also have a "reason" property so that they are human-readable.
+    Note that the returned JSON object will be a dict unless jsonify_response
+    is enabled, in which case it will return JSON that Flask can respond with.
+    This helper will not raise the exception passed in, it will only turn
+    it into a JSON object.
+
+    Parameters
+    ==========
+
+    exception : Exception
+       Exception to convert to a JSON object
+    jsonify_response : bool
+       Whether or not to call 'jsonify' on the resulting dict
+
+    Returns:
+       JSON object, HTTP status code
+    """
     if isinstance(exception, FuncxResponseError):
         # the pack method turns a FuncxResponseError into a record
         # which will become json
         response = exception.pack()
         status_code = int(exception.http_status_code)
     else:
+        # if the error is not recognized as a FuncxResponseError, a generic
+        # response of the same format will be sent back, indicating an
+        # internal server error
         response = {'status': 'Failed',
                     'code': 0,
                     'error_args': [],

--- a/funcx_web_service/errors.py
+++ b/funcx_web_service/errors.py
@@ -1,5 +1,5 @@
 class FuncxError(Exception):
-    """ Base class for all Forwarder exceptions
+    """ Base class for all web service exceptions
     """
 
     def __init__(self, reason):
@@ -10,16 +10,56 @@ class FuncxError(Exception):
 
 
 class UserNotFound(FuncxError):
-    """ Base class for all Forwarder exceptions
+    """ User not found exception
     """
 
     def __init__(self, reason):
         self.reason = reason
 
+    def __repr__(self):
+        return self.reason
 
-class MissingFunction(FuncxError):
+
+class FunctionNotFound(FuncxError):
     """ Function could not be resolved from the database
     """
     def __init__(self, uuid):
-        self.reason = "FunctionID {} could not be resolved".format(uuid)
+        self.reason = "Function {} could not be resolved".format(uuid)
         self.uuid = uuid
+
+    def __repr__(self):
+        return self.reason
+
+
+class EndpointNotFound(FuncxError):
+    """ Endpoint could not be resolved from the database
+    """
+    def __init__(self, uuid):
+        self.reason = "Endpoint {} could not be resolved".format(uuid)
+        self.uuid = uuid
+
+    def __repr__(self):
+        return self.reason
+
+
+class FunctionNotPermitted(FuncxError):
+    """ Function not permitted on endpoint
+    """
+    def __init__(self, function_uuid, endpoint_uuid):
+        self.reason = "Function {} not permitted on endpoint {}".format(function_uuid, endpoint_uuid)
+        self.function_uuid = function_uuid
+        self.endpoint_uuid = endpoint_uuid
+
+    def __repr__(self):
+        return self.reason
+
+
+class ForwarderRegistrationError(FuncxError):
+    """ Registering the endpoint with the forwarder has failed
+    """
+
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __repr__(self):
+        return "Endpoint registration with forwarder failed due to {}".format(self.reason)

--- a/funcx_web_service/errors.py
+++ b/funcx_web_service/errors.py
@@ -1,5 +1,6 @@
 class FuncxError(Exception):
-    """ Base class for all web service exceptions
+    """ Base class for all web service exceptions not related to service responses
+    (for web service response exceptions, see: funcx.utils.response_errors)
     """
 
     def __init__(self, reason):
@@ -7,59 +8,3 @@ class FuncxError(Exception):
 
     def __str__(self):
         return self.__repr__()
-
-
-class UserNotFound(FuncxError):
-    """ User not found exception
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __repr__(self):
-        return self.reason
-
-
-class FunctionNotFound(FuncxError):
-    """ Function could not be resolved from the database
-    """
-    def __init__(self, uuid):
-        self.reason = "Function {} could not be resolved".format(uuid)
-        self.uuid = uuid
-
-    def __repr__(self):
-        return self.reason
-
-
-class EndpointNotFound(FuncxError):
-    """ Endpoint could not be resolved from the database
-    """
-    def __init__(self, uuid):
-        self.reason = "Endpoint {} could not be resolved".format(uuid)
-        self.uuid = uuid
-
-    def __repr__(self):
-        return self.reason
-
-
-class FunctionNotPermitted(FuncxError):
-    """ Function not permitted on endpoint
-    """
-    def __init__(self, function_uuid, endpoint_uuid):
-        self.reason = "Function {} not permitted on endpoint {}".format(function_uuid, endpoint_uuid)
-        self.function_uuid = function_uuid
-        self.endpoint_uuid = endpoint_uuid
-
-    def __repr__(self):
-        return self.reason
-
-
-class ForwarderRegistrationError(FuncxError):
-    """ Registering the endpoint with the forwarder has failed
-    """
-
-    def __init__(self, reason):
-        self.reason = reason
-
-    def __repr__(self):
-        return "Endpoint registration with forwarder failed due to {}".format(self.reason)

--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -5,7 +5,7 @@ import redis
 from flask import current_app as app
 
 from funcx_web_service.models import search
-from funcx_web_service.errors import FunctionNotFound
+from funcx.utils.response_errors import FunctionNotFound
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.tasks import DBTask

--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -5,7 +5,7 @@ import redis
 from flask import current_app as app
 
 from funcx_web_service.models import search
-from funcx.utils.response_errors import FunctionNotFound
+from funcx.utils.response_errors import FunctionNotFound, EndpointAlreadyRegistered
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.tasks import DBTask
@@ -220,7 +220,7 @@ def register_endpoint(user: User, endpoint_name, description, endpoint_uuid=None
             else:
                 app.logger.debug(f"Endpoint {endpoint_uuid} was previously registered "
                                  f"with user {existing_endpoint.user_id} not {user_id}")
-                raise Exception(f"Endpoint {endpoint_uuid} was already registered by a different user")
+                raise EndpointAlreadyRegistered(endpoint_uuid)
     else:
         endpoint_uuid = str(uuid.uuid4())
     try:

--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -5,7 +5,7 @@ import redis
 from flask import current_app as app
 
 from funcx_web_service.models import search
-from funcx_web_service.errors import MissingFunction
+from funcx_web_service.errors import FunctionNotFound
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.tasks import DBTask
@@ -262,7 +262,7 @@ def resolve_function(user_id, function_uuid):
     saved_function = Function.find_by_uuid(function_uuid)
 
     if not saved_function:
-        raise MissingFunction(function_uuid)
+        raise FunctionNotFound(function_uuid)
 
     function_code = saved_function.function_source_code
     function_entry = saved_function.entry_point

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -844,15 +844,15 @@ def register_endpoint_2(user: User, user_uuid: str):
 
     except KeyError as e:
         app.logger.exception("Missing keys in json request")
-        return create_error_response(RequestKeyError(str(e)), True)
+        return jsonify(create_error_response(RequestKeyError(str(e))))
 
     except UserNotFound as e:
         app.logger.exception("User not found")
-        return create_error_response(e, True)
+        return jsonify(create_error_response(e))
 
     except Exception as e:
         app.logger.exception("Caught error while registering endpoint")
-        return create_error_response(e, True)
+        return jsonify(create_error_response(e))
 
     try:
         forwarder_ip = app.config['FORWARDER_IP']
@@ -862,7 +862,7 @@ def register_endpoint_2(user: User, user_uuid: str):
 
     except Exception as e:
         app.logger.exception("Caught error during forwarder initialization")
-        return create_error_response(e, True)
+        return jsonify(create_error_response(e))
 
     if 'meta' in request.json and endpoint_uuid:
         ingest_endpoint(user.username, user_uuid, endpoint_uuid, request.json['meta'])

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -765,11 +765,10 @@ def get_ep_stats(user: User, endpoint_id):
 
     try:
         if not authorize_endpoint(user_id, endpoint_id, None, token):
-            return jsonify({'status': 'Failed',
-                            'reason': f'Unauthorized access to endpoint: {endpoint_id}'})
+            return jsonify(create_error_response(UnauthorizedEndpointAccess(endpoint_id)))
     except Exception as e:
-        return jsonify({'status': 'Failed',
-                        'reason': f'Endpoint authorization failed. {e}'})
+        # could be EndpointNotFound
+        return jsonify(create_error_response(e))
 
     # TODO add rc to g.
     rc = get_redis_client()

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -5,7 +5,6 @@ import requests
 
 from flask import current_app as app, Blueprint, jsonify, request, abort, send_from_directory, g
 
-from funcx.utils.errors import RegistrationError
 from funcx_web_service.authentication.auth import authenticated_w_uuid
 from funcx_web_service.authentication.auth import authorize_endpoint, authenticated, authorize_function
 
@@ -16,6 +15,7 @@ from funcx_web_service.models.utils import register_endpoint, ingest_function
 from funcx_web_service.models.utils import resolve_function, db_invocation_logger
 from funcx_web_service.models.utils import (update_function, delete_function, get_ep_whitelist,
                                             add_ep_whitelist, delete_ep_whitelist)
+from funcx_web_service.errors import UserNotFound, ForwarderRegistrationError
 from funcx_web_service.version import VERSION
 
 from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
@@ -24,7 +24,6 @@ from .redis_q import EndpointQueue
 from funcx.sdk.version import VERSION as FUNCX_VERSION
 
 # Flask
-from ..errors import UserNotFound
 from ..models.auth_groups import AuthGroup
 from ..models.container import Container, ContainerImage
 from ..models.endpoint import Endpoint
@@ -86,23 +85,23 @@ def auth_and_launch(user_id, function_uuid, endpoints, input_data, app, token, s
                     'reason': f'Unauthorized access to function: {function_uuid}'}
     except Exception as e:
         return {'status': 'Failed',
-                'reason': f'Function authorization failed - {e}'}
+                'reason': f'Function authorization failed. {str(e)}'}
 
     try:
         fn_code, fn_entry, container_uuid = resolve_function(user_id, function_uuid)
     except Exception as e:
         return {'status': 'Failed',
-                'reason': f'Function UUID:{function_uuid} could not be resolved. {e}'}
+                'reason': f'Function {function_uuid} could not be resolved. {e}'}
 
     # Make sure the user is allowed to use the function on this endpoint
-    try:
-        for ep in endpoints:
+    for ep in endpoints:
+        try:
             if not authorize_endpoint(user_id, ep, function_uuid, token):
                 return {'status': 'Failed',
                         'reason': f'Unauthorized access to endpoint: {ep}'}
-    except Exception as e:
-        return {'status': 'Failed',
-                'reason': f'Endpoint authorization failed - {e}'}
+        except Exception as e:
+            return {'status': 'Failed',
+                    'reason': f'Endpoint authorization failed for endpoint {ep}. {e}'}
 
     app.logger.debug(f"Got function container_uuid :{container_uuid}")
 
@@ -634,7 +633,7 @@ def register_with_hub(address, endpoint_id, endpoint_address):
     if r.status_code != 200:
         print(dir(r))
         print(r)
-        raise RegistrationError(r.reason)
+        raise ForwarderRegistrationError(r.reason)
 
     return r.json()
 
@@ -773,7 +772,7 @@ def get_ep_stats(user: User, endpoint_id):
                             'reason': f'Unauthorized access to endpoint: {endpoint_id}'})
     except Exception as e:
         return jsonify({'status': 'Failed',
-                        'reason': f'Endpoint authorization failed - {e}'})
+                        'reason': f'Endpoint authorization failed. {e}'})
 
     # TODO add rc to g.
     rc = get_redis_client()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ Flask-SocketIO==4.3.0
 flask-sqlalchemy
 Flask-Migrate==2.5.3
 Flask-WTF==0.14.3
-git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
-git+https://github.com/funcx-faas/funcx-forwarder.git@forwarder_redesign#egg=funcx-forwarder
+git+https://github.com/funcx-faas/funcX.git@refactor_res_errors#egg=funcx&subdirectory=funcx_sdk
+git+https://github.com/funcx-faas/funcx-forwarder.git@add_funcx_endpoint_dep#egg=funcx-forwarder
 globus-nexus-client==0.2.9
 globus-sdk==1.9.0
 greenlet==0.4.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ Flask-SocketIO==4.3.0
 flask-sqlalchemy
 Flask-Migrate==2.5.3
 Flask-WTF==0.14.3
-git+https://github.com/funcx-faas/funcX.git@refactor_res_errors#egg=funcx&subdirectory=funcx_sdk
-git+https://github.com/funcx-faas/funcx-forwarder.git@add_funcx_endpoint_dep#egg=funcx-forwarder
+git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
+git+https://github.com/funcx-faas/funcx-forwarder.git@forwarder_redesign#egg=funcx-forwarder
 globus-nexus-client==0.2.9
 globus-sdk==1.9.0
 greenlet==0.4.16

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -2,15 +2,11 @@ import pytest
 
 from funcx_web_service.authentication.auth import authorize_endpoint, authorize_function
 from funcx_web_service.models.function import Function, FunctionAuthGroup
+from tests.routes.app_test_base import AppTestBase
 
 
-@pytest.fixture
-def mock_app_logger(mocker):
-    return mocker.patch("funcx_web_service.authentication.auth.app")
-
-
-class TestAuth:
-    def test_authorize_endpoint_restricted_whitelist(self, mocker, mock_app_logger):
+class TestAuth(AppTestBase):
+    def test_authorize_endpoint_restricted_whitelist(self, mocker):
         """
         Test to see that we are authorized if the endpoint is restricted, but the
         requested function is in the whitelist
@@ -26,6 +22,7 @@ class TestAuth:
                                                          Function(function_uuid="123")
                                                      ]
                                                  ))
+
         result = authorize_endpoint(user_id="test_user",
                                     endpoint_uuid="123-45-566",
                                     function_uuid="123",
@@ -33,7 +30,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_restricted_not_whitelist(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_restricted_not_whitelist(self, mocker):
         """
         Test to see that we are authorized if the endpoint is restricted, and the
         requested function is not in the whitelist
@@ -59,7 +56,7 @@ class TestAuth:
             print(excinfo)
             mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_public(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_public(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         authorize_endpoint.cache_clear()
 
@@ -76,7 +73,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_user(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_user(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         authorize_endpoint.cache_clear()
 
@@ -94,7 +91,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_group(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_group(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         from funcx_web_service.models.auth_groups import AuthGroup
         authorize_endpoint.cache_clear()
@@ -127,7 +124,7 @@ class TestAuth:
         mock_auth_group_find.assert_called_with("123-45-566")
         mock_check_group_membership.assert_called_with("ttttt", ['my-group'])
 
-    def test_authorize_endpoint_no_group(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_no_group(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         from funcx_web_service.models.auth_groups import AuthGroup
         authorize_endpoint.cache_clear()
@@ -157,7 +154,7 @@ class TestAuth:
         mock_auth_group_find.assert_called_with("123-45-566")
         mock_check_group_membership.assert_not_called()
 
-    def test_authorize_function_user_owns(self, mocker, mock_app_logger):
+    def test_authorize_function_user_owns(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 
@@ -173,7 +170,7 @@ class TestAuth:
         assert result
         mock_function_find.assert_called_with("123")
 
-    def test_authorize_function_public(self, mocker, mock_app_logger):
+    def test_authorize_function_public(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 
@@ -189,7 +186,7 @@ class TestAuth:
         assert result
         mock_function_find.assert_called_with("123")
 
-    def test_authorize_function_auth_group(self, mocker, mock_app_logger):
+    def test_authorize_function_auth_group(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 

--- a/tests/routes/app_test_base.py
+++ b/tests/routes/app_test_base.py
@@ -12,3 +12,11 @@ class AppTestBase:
         })
         app.secret_key = "Shhhhh"
         return app.test_client()
+
+    def setup_method(self, method):
+        self.client = self.test_client()
+        self.app_context = self.client.application.app_context()
+        self.app_context.push()
+
+    def teardown_method(self, method):
+        self.app_context.pop()

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -9,7 +9,7 @@ class TestAuth(AppTestBase):
         mock_client.oauth2_get_authorize_url = mocker.Mock(return_value="http://secure.org")
         mocker.patch("funcx_web_service.routes.auth.get_auth_client", return_value=mock_client)
 
-        client = self.test_client()
+        client = self.client
         result = client.get("/callback")
         assert result.status_code == 302
         assert result.headers['Location'] == 'http://secure.org'
@@ -18,7 +18,7 @@ class TestAuth(AppTestBase):
         mock_flash = mocker.patch("funcx_web_service.routes.auth.flash")
         mocker.patch("funcx_web_service.routes.auth.url_for", return_value="http://funcx.home")
 
-        client = self.test_client()
+        client = self.client
 
         result = client.get('/callback?error=FATAL&error_description="bad stuff"')
         assert result.status_code == 302
@@ -39,7 +39,7 @@ class TestAuth(AppTestBase):
         mock_client.oauth2_exchange_code_for_tokens = mocker.Mock(return_value=mock_tokens)
         mocker.patch("funcx_web_service.routes.auth.get_auth_client", return_value=mock_client)
 
-        client = self.test_client()
+        client = self.client
 
         result = client.get("/callback?code=foo")
         assert result.status_code == 302

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -232,6 +232,9 @@ class TestFuncX(AppTestBase):
                              },
                              headers={"Authorization": "my_token"})
         assert result.status_code == 400
+        assert result.json['status'] == 'Failed'
+        assert result.json['code'] == int(ResponseErrorCode.REQUEST_KEY_ERROR)
+        assert result.json['reason'] ==  "Missing key in JSON request - 'name'"
 
     def test_register_endpoint(self, mocker, mock_auth_client, mock_user):
         client = self.client
@@ -278,7 +281,9 @@ class TestFuncX(AppTestBase):
                              headers={"Authorization": "my_token"})
         get_forwarder_version.assert_called()
         assert result.status_code == 400
-        assert "Endpoint is out of date." in result.data.decode("utf-8")
+        assert result.json['status'] == 'Failed'
+        assert result.json['code'] == int(ResponseErrorCode.ENDPOINT_OUTDATED)
+        assert "Endpoint is out of date." in result.json['reason']
 
     def test_register_endpoint_no_version(self, mocker, mock_auth_client):
         client = self.client
@@ -292,7 +297,9 @@ class TestFuncX(AppTestBase):
                              headers={"Authorization": "my_token"})
         get_forwarder_version.assert_called()
         assert result.status_code == 400
-        assert "version must be passed in" in result.data.decode("utf-8")
+        assert result.json['status'] == 'Failed'
+        assert result.json['code'] == int(ResponseErrorCode.REQUEST_KEY_ERROR)
+        assert "version must be passed in" in result.json['reason']
 
     def test_register_endpoint_missing_keys(self, mocker, mock_auth_client):
         client = self.client

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -3,7 +3,9 @@ import pytest
 from funcx_web_service.models.container import Container
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.user import User
+from funcx.utils.response_errors import ResponseErrorCode
 from tests.routes.app_test_base import AppTestBase
+
 
 
 @pytest.fixture
@@ -282,3 +284,32 @@ class TestFuncX(AppTestBase):
         get_forwarder_version.assert_called()
         assert result.status_code == 400
         assert "version must be passed in" in result.data.decode("utf-8")
+
+    def test_register_endpoint_missing_keys(self, mocker, mock_auth_client):
+        client = self.client
+
+        get_forwarder_version = mocker.patch(
+            "funcx_web_service.routes.funcx.get_forwarder_version",
+            return_value={"min_ep_version": "1.0.0"})
+
+        result = client.post("api/v1/register_endpoint_2",
+                             json={
+                                 "version": "1.0.0",
+                                 "endpoint_uuid": None
+                             },
+                             headers={"Authorization": "my_token"})
+        get_forwarder_version.assert_called()
+
+        assert result.status_code == 200
+        assert result.json['status'] == 'Failed'
+        assert result.json['code'] == int(ResponseErrorCode.REQUEST_KEY_ERROR)
+
+    @pytest.mark.skip()
+    def test_register_endpoint_user_not_found(self):
+        return
+
+    @pytest.mark.skip()
+    def test_register_endpoint_unknown_error(self):
+        # mock the register_endpoint function called within this route to
+        # raise an unknown exception
+        return

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -300,7 +300,7 @@ class TestFuncX(AppTestBase):
                              headers={"Authorization": "my_token"})
         get_forwarder_version.assert_called()
 
-        assert result.status_code == 200
+        assert result.status_code == 400
         assert result.json['status'] == 'Failed'
         assert result.json['code'] == int(ResponseErrorCode.REQUEST_KEY_ERROR)
 


### PR DESCRIPTION
This PR goes along with: https://github.com/funcx-faas/funcX/pull/360

Errors related to sdk service responses would be moved to the funcx sdk, though they would still be used here. This would just require carefully putting together a useful list of errors so that it doesn't have to be changed much later.

Whenever an error is encountered while handling a service request, it should simply be passed into `create_error_response(e)` where it is turned into a json message that can be sent to the client. Useful info is put into the json response message so that the same error can be produced on the client side.

I have only implemented this for the route `/register_endpoint_2` as an example