### PR TITLE
Move funcx-forwarder install before latest funcx sdk install in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ WORKDIR /opt/funcx-web-service
 COPY ./requirements.txt .
 
 RUN pip install -r requirements.txt
+RUN pip install "git+https://github.com/funcx-faas/funcx-forwarder.git@forwarder_redesign#egg=funcx-forwarder"
 RUN  pip uninstall -y funcx && \
      pip install "git+https://github.com/funcx-faas/funcX.git@forwarder_rearch_1#egg=funcx&subdirectory=funcx_sdk"
      #pip install "git+https://github.com/funcx-faas/funcX.git@dev#egg=funcx&subdirectory=funcx_sdk"
 
 RUN pip install "git+https://github.com/funcx-faas/funcX.git@forwarder_rearch_1#egg=funcx_endpoint&subdirectory=funcx_endpoint"
-RUN pip install "git+https://github.com/funcx-faas/funcx-forwarder.git@forwarder_redesign#egg=funcx-forwarder"
 
 RUN pip install --disable-pip-version-check uwsgi
 


### PR DESCRIPTION
It seems that installing funcx-forwarder after the desired funcx version can result in an undesired funcx version. Docker build output of this happening:

```
Successfully built funcx-forwarder
Installing collected packages: parsl, funcx, funcx-forwarder
  Attempting uninstall: parsl
    Found existing installation: parsl 1.1.0a0
    Uninstalling parsl-1.1.0a0:
      Successfully uninstalled parsl-1.1.0a0
  Attempting uninstall: funcx
    Found existing installation: funcx 0.0.6a0
    Uninstalling funcx-0.0.6a0:
      Successfully uninstalled funcx-0.0.6a0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
funcx-endpoint 0.0.6a2 requires funcx>=0.0.6a0, but you have funcx 0.0.5 which is incompatible.
Successfully installed funcx-0.0.5 funcx-forwarder-0.0.2 parsl-0.9.0
```