### PR TITLE
Handle flask app context better using test base class

### DIFF
--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -2,15 +2,11 @@ import pytest
 
 from funcx_web_service.authentication.auth import authorize_endpoint, authorize_function
 from funcx_web_service.models.function import Function, FunctionAuthGroup
+from tests.routes.app_test_base import AppTestBase
 
 
-@pytest.fixture
-def mock_app_logger(mocker):
-    return mocker.patch("funcx_web_service.authentication.auth.app")
-
-
-class TestAuth:
-    def test_authorize_endpoint_restricted_whitelist(self, mocker, mock_app_logger):
+class TestAuth(AppTestBase):
+    def test_authorize_endpoint_restricted_whitelist(self, mocker):
         """
         Test to see that we are authorized if the endpoint is restricted, but the
         requested function is in the whitelist
@@ -26,6 +22,7 @@ class TestAuth:
                                                          Function(function_uuid="123")
                                                      ]
                                                  ))
+
         result = authorize_endpoint(user_id="test_user",
                                     endpoint_uuid="123-45-566",
                                     function_uuid="123",
@@ -33,7 +30,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_restricted_not_whitelist(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_restricted_not_whitelist(self, mocker):
         """
         Test to see that we are authorized if the endpoint is restricted, and the
         requested function is not in the whitelist
@@ -59,7 +56,7 @@ class TestAuth:
             print(excinfo)
             mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_public(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_public(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         authorize_endpoint.cache_clear()
 
@@ -76,7 +73,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_user(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_user(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         authorize_endpoint.cache_clear()
 
@@ -94,7 +91,7 @@ class TestAuth:
         assert result
         mock_endpoint_find.assert_called_with("123-45-566")
 
-    def test_authorize_endpoint_group(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_group(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         from funcx_web_service.models.auth_groups import AuthGroup
         authorize_endpoint.cache_clear()
@@ -127,7 +124,7 @@ class TestAuth:
         mock_auth_group_find.assert_called_with("123-45-566")
         mock_check_group_membership.assert_called_with("ttttt", ['my-group'])
 
-    def test_authorize_endpoint_no_group(self, mocker, mock_app_logger):
+    def test_authorize_endpoint_no_group(self, mocker):
         from funcx_web_service.models.endpoint import Endpoint
         from funcx_web_service.models.auth_groups import AuthGroup
         authorize_endpoint.cache_clear()
@@ -157,7 +154,7 @@ class TestAuth:
         mock_auth_group_find.assert_called_with("123-45-566")
         mock_check_group_membership.assert_not_called()
 
-    def test_authorize_function_user_owns(self, mocker, mock_app_logger):
+    def test_authorize_function_user_owns(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 
@@ -173,7 +170,7 @@ class TestAuth:
         assert result
         mock_function_find.assert_called_with("123")
 
-    def test_authorize_function_public(self, mocker, mock_app_logger):
+    def test_authorize_function_public(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 
@@ -189,7 +186,7 @@ class TestAuth:
         assert result
         mock_function_find.assert_called_with("123")
 
-    def test_authorize_function_auth_group(self, mocker, mock_app_logger):
+    def test_authorize_function_auth_group(self, mocker):
         from funcx_web_service.models.function import Function
         authorize_function.cache_clear()
 

--- a/tests/routes/app_test_base.py
+++ b/tests/routes/app_test_base.py
@@ -12,3 +12,13 @@ class AppTestBase:
         })
         app.secret_key = "Shhhhh"
         return app.test_client()
+
+
+    def setup_method(self, method):
+        self.client = self.test_client()
+        self.app_context = self.client.application.app_context()
+        self.app_context.push()
+
+
+    def teardown_method(self, method):
+        self.app_context.pop()

--- a/tests/routes/app_test_base.py
+++ b/tests/routes/app_test_base.py
@@ -13,12 +13,10 @@ class AppTestBase:
         app.secret_key = "Shhhhh"
         return app.test_client()
 
-
     def setup_method(self, method):
         self.client = self.test_client()
         self.app_context = self.client.application.app_context()
         self.app_context.push()
-
 
     def teardown_method(self, method):
         self.app_context.pop()

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -9,7 +9,7 @@ class TestAuth(AppTestBase):
         mock_client.oauth2_get_authorize_url = mocker.Mock(return_value="http://secure.org")
         mocker.patch("funcx_web_service.routes.auth.get_auth_client", return_value=mock_client)
 
-        client = self.test_client()
+        client = self.client
         result = client.get("/callback")
         assert result.status_code == 302
         assert result.headers['Location'] == 'http://secure.org'
@@ -18,7 +18,7 @@ class TestAuth(AppTestBase):
         mock_flash = mocker.patch("funcx_web_service.routes.auth.flash")
         mocker.patch("funcx_web_service.routes.auth.url_for", return_value="http://funcx.home")
 
-        client = self.test_client()
+        client = self.client
 
         result = client.get('/callback?error=FATAL&error_description="bad stuff"')
         assert result.status_code == 302
@@ -39,7 +39,7 @@ class TestAuth(AppTestBase):
         mock_client.oauth2_exchange_code_for_tokens = mocker.Mock(return_value=mock_tokens)
         mocker.patch("funcx_web_service.routes.auth.get_auth_client", return_value=mock_client)
 
-        client = self.test_client()
+        client = self.client
 
         result = client.get("/callback?code=foo")
         assert result.status_code == 302


### PR DESCRIPTION
I noticed that pretty much all tests at the moment need either the the flask `test_client` in order to make requests, or the `app_context` in order to use the utils that flask provides. This can be solved using pytest's `setup_method` and `teardown_method` in order to create a new client for each test, as well as push and pop the context for each test.

I think this will make writing tests a little more straightforward without having to mess around with flask context, but let me know if you see any downsides to this approach.