### PR TITLE
Fix the reference to FunctionContainer. 

### DIFF
--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -268,7 +268,7 @@ def resolve_function(user_id, function_uuid):
     function_entry = saved_function.entry_point
 
     if saved_function.container:
-        container_uuid = saved_function.container.container_uuid
+        container_uuid = saved_function.container.container.container_uuid
     else:
         container_uuid = None
 


### PR DESCRIPTION
The Back Populate of `function = relationship("Function", back_populates='container')` introduces a `FunctionContainer` object in the `Function` instance called `container` - this needs to be dereferenced to get to the container uuid