### PR TITLE
470 function auth groups

### DIFF
--- a/funcx_web_service/models/auth_groups.py
+++ b/funcx_web_service/models/auth_groups.py
@@ -10,10 +10,6 @@ class AuthGroup(db.Model):
     group_id = Column(String(67))
     endpoint_id = Column(String(67))
 
-    def save_to_db(self):
-        db.session.add(self)
-        db.session.commit()
-
     @classmethod
     def find_by_uuid(cls, uuid):
         try:

--- a/funcx_web_service/models/auth_groups.py
+++ b/funcx_web_service/models/auth_groups.py
@@ -1,5 +1,4 @@
 from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
 
 from funcx_web_service.models import db
@@ -10,8 +9,6 @@ class AuthGroup(db.Model):
     id = Column(Integer, primary_key=True)
     group_id = Column(String(67))
     endpoint_id = Column(String(67))
-
-    functions = relationship("FunctionAuthGroup")
 
     def save_to_db(self):
         db.session.add(self)

--- a/funcx_web_service/models/function.py
+++ b/funcx_web_service/models/function.py
@@ -68,11 +68,9 @@ class FunctionContainer(db.Model):
 class FunctionAuthGroup(db.Model):
     __tablename__ = "function_auth_groups"
     id = db.Column(Integer, primary_key=True)
-    group_id = db.Column(Integer, ForeignKey("auth_groups.id"))
+    group_id = db.Column(String(38))
     function_id = db.Column(Integer, ForeignKey('functions.id'))
-
     function = relationship("Function", back_populates='auth_groups')
-    group = relationship("AuthGroup", back_populates='functions')
 
     @classmethod
     def find_by_function_uuid(cls, function_id):

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -22,14 +22,13 @@ from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
 from .redis_q import EndpointQueue
 
 from funcx.utils.response_errors import (UserNotFound, ContainerNotFound, TaskNotFound,
-                                         AuthGroupNotFound, FunctionAccessForbidden, EndpointAccessForbidden,
+                                         FunctionAccessForbidden, EndpointAccessForbidden,
                                          ForwarderRegistrationError, ForwarderContactError, EndpointStatsError,
                                          LivenessStatsError, RequestKeyError, RequestMalformed, InternalError,
                                          EndpointOutdated)
 from funcx.sdk.version import VERSION as FUNCX_VERSION
 
 # Flask
-from ..models.auth_groups import AuthGroup
 from ..models.container import Container, ContainerImage
 from ..models.endpoint import Endpoint
 from ..models.function import Function, FunctionContainer, FunctionAuthGroup
@@ -767,12 +766,6 @@ def reg_function(user: User, user_uuid):
                 return create_error_response(ContainerNotFound(container_uuid), jsonify_response=True)
 
         group_uuid = request.json.get("group", None)
-        group = None
-        if group_uuid:
-            group = AuthGroup.find_by_uuid(group_uuid)
-            if not group:
-                return create_error_response(AuthGroupNotFound(group_uuid), jsonify_response=True)
-
         searchable = request.json.get("searchable", True)
 
         app.logger.info(f"Registering function {function_rec.function_name} "
@@ -784,10 +777,10 @@ def reg_function(user: User, user_uuid):
                 container=container
             )
 
-        if group:
+        if group_uuid:
             function_rec.auth_groups = [
                 FunctionAuthGroup(
-                    group=group,
+                    group_id=group_uuid,
                     function=function_rec
                 )
             ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ dill==0.3.2
 dnspython==1.16.0
 docutils==0.16
 entrypoints==0.3
-eventlet==0.25.2
 fair-research-login==0.1.5
 Flask==1.1.2
 Flask-SocketIO==4.3.0

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -183,12 +183,6 @@ class TestFuncX(AppTestBase):
         )
         mocker.patch.object(User, "find_by_username", return_value=mock_user)
 
-        from funcx_web_service.models.auth_groups import AuthGroup
-        mock_auth_group = AuthGroup(
-            id=45
-        )
-
-        mock_authgroup_read = mocker.patch.object(AuthGroup, "find_by_uuid", return_value=mock_auth_group)
         result = client.post("api/v1/functions",
                              json={
                                  "function_source": "def fun(x): return x+1",
@@ -201,14 +195,14 @@ class TestFuncX(AppTestBase):
                                  "group": '222-111'
                              },
                              headers={"Authorization": "my_token"})
+
         assert result.status_code == 200
         assert "function_uuid" in result.json
         assert mock_ingest.not_called
-        mock_authgroup_read.assert_called_with("222-111")
 
         saved_function = Function.find_by_uuid(result.json['function_uuid'])
         assert len(saved_function.auth_groups) == 1
-        assert saved_function.auth_groups[0].group_id == 45
+        assert saved_function.auth_groups[0].group_id == "222-111"
 
     def test_register_container(self, mocker, mock_auth_client):
         client = self.client


### PR DESCRIPTION
# Problem
The table that permits access to functions to members of a group was incorrectly ported to SqlAlchemy as a join between AuthGroup and Function. This is not correct. It should simply be a lookup table for functions that provides a Globus Auth group UUID

Fixes [Issue 470](https://github.com/funcx-faas/funcX/issues/470)

# Approach
1. Changed the type of `group_id` to be a 38 character string.
2. Created an alembic DB migration
3. Removed the relatinships between this table and AuthGroup table

Also fixed a stale dependency
