### PR TITLE
Add flask logging

### DIFF
--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from funcx_web_service.routes.auth import auth_api
 from flask import Flask
 from funcx_web_service.routes.automate import automate_api
@@ -6,6 +8,7 @@ from funcx_web_service.routes.funcx import funcx_api
 
 def create_app(test_config=None):
     application = Flask(__name__)
+    application.logger.setLevel(os.environ.get('LOGLEVEL', 'WARNING').upper())
 
     if test_config:
         application.config.from_mapping(test_config)

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,4 +5,5 @@ plugin = python37,http
 http = 0.0.0.0:5000
 manage-script-name = true
 http-keepalive = 1
+log-master=true
 module = funcx_web_service.application:app


### PR DESCRIPTION
# Problem
The web app is no longer logging and it is impossible to set the log level

Fixes #220 

Depends on [HelmChart PR 17](https://github.com/funcx-faas/helm-chart/pull/17) 



# Approach
Added a line to the app's __init__ script to initialize the logger and set the level from an environment var.

Also updated the uWSGI config to insure that the output from the flask app is included in stdout for the docker container.