### PR TITLE
Incorporate initial pre-commit config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,15 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Get latest pip version
       run: |
         python -m pip install --upgrade pip setuptools wheel
+    - name: Lint
+      run: |
+        pip install pre-commit
+        pre-commit run -a
+    - name: Install dependencies
+      run: |
         python -m pip install -r requirements.txt --use-deprecated=legacy-resolver
         python -m pip install -r requirements_test.txt --use-deprecated=legacy-resolver
         pip list
@@ -31,9 +37,6 @@ jobs:
       run: |
         pip install safety
         pip freeze | safety check
-    - name: Lint with Flake8
-      run: |
-        flake8
     - name: Test with pytest
       run: |
         python -m coverage run -m pytest -r sx tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+- repo: meta
+  hooks:
+    - id: check-hooks-apply
+    - id: check-useless-excludes
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  rev: v4.0.1
+  hooks:
+    - id: check-merge-conflict
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.3.1
+  hooks:
+    - id: check-github-workflows
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+    - id: flake8
+      # because pre-commit invokes flake8 directly on files, the exclude in
+      # `.flake8` config does not apply and the files must be excluded from the hook
+      exclude: ^migrations/.*
+      additional_dependencies: ['flake8-bugbear==21.4.3']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guide
+
+This doc covers dev setup and guidelines for contributing.
+
+FIXME: This doc is a stub.
+
+## Requirements
+
+- python3.7+ (prefer 3.7), pip, virtualenv
+- docker
+
+### Recommended
+
+- [pipx](https://pypa.github.io/pipx/)
+- [pre-commit](https://pre-commit.com/)
+
+You can install `pipx` first, and then use it to install other tools, as in
+
+    pipx install pre-commit
+
+## Linting & Testing
+
+Testing should be done in a virtualenv with pytest. Setup:
+
+    pip install -r ./requirements.txt
+    pip install -r ./requirements_test.txt
+
+Run tests with
+
+    pytest
+
+Linting can be run via pre-commit. Run for all files in the repo:
+
+    pre-commit run -a
+
+### (Optional) Setup pre-commit Hooks
+
+For the best development experience, set up linting and autofixing pre-commit
+git hooks using the `pre-commit` tool.
+
+After installing `pre-commit`, run
+
+    pre-commit install
+
+in the repo to configure hooks.
+
+> NOTE: If necessary, you can always skip hooks with `git commit --no-verify`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,7 @@ FIXME: This doc is a stub.
 
 ### Recommended
 
-- [pipx](https://pypa.github.io/pipx/)
 - [pre-commit](https://pre-commit.com/)
-
-You can install `pipx` first, and then use it to install other tools, as in
-
-    pipx install pre-commit
 
 ## Linting & Testing
 

--- a/integration_tests/integration_test.py
+++ b/integration_tests/integration_test.py
@@ -70,7 +70,7 @@ delta = time.time() - start
 print("Time to launch {} tasks: {:8.3f} s".format(task_count * len(func_ids), delta))
 print("Got {} tasks_ids ".format(len(task_ids)))
 
-for i in range(10):
+for _i in range(10):
     x = fxc.get_batch_status(task_ids)
     complete_count = sum([1 for t in task_ids if t in x and not x[t].get('pending', True)])
     print("Batch status : {}/{} complete".format(complete_count, len(task_ids)))


### PR DESCRIPTION
At present, [`pre-commit`](pre-commit.com) is pretty much the only standardized way for configuring git hooks, especially for the python ecosystem. It's widely used: [attrs](https://github.com/python-attrs/attrs/blob/main/.pre-commit-config.yaml), [pip](https://github.com/pypa/pip/blob/main/.pre-commit-config.yaml), and [marshmallow](https://github.com/marshmallow-code/marshmallow/blob/dev/.pre-commit-config.yaml) use it, to give some examples. Closer to funcX, various Globus projects like [globus-sdk](https://github.com/globus/globus-sdk-python/blob/main/.pre-commit-config.yaml) rely on it to organize and apply linting rules.

I can say from experience that it reduces the time necessary to get code ready for review. You have many fewer commits which fail linting, potentially in CI while you've gone to fix yourself a coffee. It also eliminates messy "fix linting" commits, since there's no need to go back and clean up.

Rather than a slow start, I figured the best way to make the case for pre-commit is to drop a config in place, mostly to cover flake8 linting. In order to explain how to set it up, I've written up an initial contrib doc for this repo which mostly boils down to `pipx install pre-commit; pre-commit install` and `pre-commit run -a`.

Warning: If you run `pre-commit install` and then switch to another branch which doesn't yet have pre-commit config, the tool will be a little confused. Until this merges, it's probably best to test by either running `pre-commit run -a`, or to make sure to `pre-commit uninstall` after testing it out (e.g. try making a commit which fails flake8 with the hook installed, see the tool stop you).

---

1. Add pre-commit config which runs flake8 with flake8-bugbear

There's one extremely minor flake8-bugbear lint failure to resolve (renaming an unused loop iteration variable).

Additional hooks included:
- meta hooks to validate pre-commit's own config
- merge-conflict hook from the "main" pre-commit hook repo
- github workflow schema validator, which uses a schemastore jsonschema to protect against commits of a class of malformed workflow files

2. Add a contrib doc which covers test and lint setup

In particular, the contrib doc serves to explain/introduce pre-commit sufficiently for everyone working on the repo to get it setup if they so choose. Setting up the hooks with `pre-commit install` is considered recommended but optional in the guide.

3. Tweak the github workflow to run pre-commit linting as early as possible

A lint-failing commit can typically be detected very quickly, relative to other steps in a workflow. For example, there's no point installing all of the dependencies of a project -- potentially a slow process -- if linting is going to fail anyway.

Because pre-commit handles the dependencies for its hooks automatically as part of the framework, the `pre-commit` lint step can run almost immediately, without depending on the python package requirements.