### PR TITLE
Add JSON logging

### DIFF
--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -1,4 +1,6 @@
 import os
+import logging
+from pythonjsonlogger import jsonlogger
 
 from funcx_web_service.routes.auth import auth_api
 from flask import Flask
@@ -6,9 +8,25 @@ from funcx_web_service.routes.automate import automate_api
 from funcx_web_service.routes.funcx import funcx_api
 
 
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        if log_record.get('level'):
+            log_record['level'] = log_record['level'].upper()
+        else:
+            log_record['level'] = record.levelname
+
+
 def create_app(test_config=None):
     application = Flask(__name__)
-    application.logger.setLevel(os.environ.get('LOGLEVEL', 'WARNING').upper())
+
+    level = os.environ.get('LOGLEVEL', 'WARNING').upper()
+    logger = application.logger
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    formatter = CustomJsonFormatter()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     if test_config:
         application.config.from_mapping(test_config)

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -8,23 +8,16 @@ from funcx_web_service.routes.automate import automate_api
 from funcx_web_service.routes.funcx import funcx_api
 
 
-class CustomJsonFormatter(jsonlogger.JsonFormatter):
-    def add_fields(self, log_record, record, message_dict):
-        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
-        if log_record.get('level'):
-            log_record['level'] = log_record['level'].upper()
-        else:
-            log_record['level'] = record.levelname
-
-
 def create_app(test_config=None):
     application = Flask(__name__)
 
-    level = os.environ.get('LOGLEVEL', 'WARNING').upper()
+    level = os.environ.get('LOGLEVEL', 'DEBUG').upper()
     logger = application.logger
+    logger.setLevel(level)
+
     handler = logging.StreamHandler()
     handler.setLevel(level)
-    formatter = CustomJsonFormatter()
+    formatter = jsonlogger.JsonFormatter('%(asctime)s %(name)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -4,6 +4,7 @@ from pythonjsonlogger import jsonlogger
 
 from funcx_web_service.routes.auth import auth_api
 from flask import Flask
+from flask.logging import default_handler
 from funcx_web_service.routes.automate import automate_api
 from funcx_web_service.routes.funcx import funcx_api
 
@@ -20,6 +21,8 @@ def create_app(test_config=None):
     formatter = jsonlogger.JsonFormatter('%(asctime)s %(name)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    logger.removeHandler(default_handler)
 
     if test_config:
         application.config.from_mapping(test_config)

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -22,6 +22,10 @@ def create_app(test_config=None):
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
+    # This removes the default Flask handler. Since we have added a JSON
+    # log formatter and handler above, we must disable the default handler
+    # to prevent duplicate log messages (where one is the normal log format
+    # and the other is JSON format).
     logger.removeHandler(default_handler)
 
     if test_config:

--- a/funcx_web_service/models/tasks.py
+++ b/funcx_web_service/models/tasks.py
@@ -94,6 +94,7 @@ class Task:
     ORM-esque class to wrap access to properties of tasks for better style and encapsulation
     """
     status = RedisField(serializer=lambda ts: ts.value, deserializer=TaskState)
+    function_id = RedisField()
     endpoint = RedisField()
     container = RedisField()
     payload = RedisField(serializer=json.dumps, deserializer=json.loads)
@@ -107,7 +108,7 @@ class Task:
     # long-lived clients, and we'll revise this if there are complaints
     TASK_TTL = timedelta(weeks=2)
 
-    def __init__(self, rc: StrictRedis, task_id: str, container: str = "", serializer: str = "", payload: str = "", task_group_id: str = ""):
+    def __init__(self, rc: StrictRedis, task_id: str, function_id: str = "", container: str = "", serializer: str = "", payload: str = "", task_group_id: str = ""):
         """ If the kwargs are passed, then they will be overwritten.  Otherwise, they will gotten from existing
         task entry.
         Parameters
@@ -129,7 +130,10 @@ class Task:
         self.hname = self._generate_hname(self.task_id)
 
         # If passed, we assume they should be set (i.e. in cases of new tasks)
-        # if not passed,
+        # if not passed, do not set
+        if function_id:
+            self.function_id = function_id
+
         if container:
             self.container = container
 

--- a/funcx_web_service/models/tasks.py
+++ b/funcx_web_service/models/tasks.py
@@ -94,6 +94,7 @@ class Task:
     ORM-esque class to wrap access to properties of tasks for better style and encapsulation
     """
     status = RedisField(serializer=lambda ts: ts.value, deserializer=TaskState)
+    user_id = RedisField(serializer=str, deserializer=int)
     function_id = RedisField()
     endpoint = RedisField()
     container = RedisField()
@@ -108,7 +109,17 @@ class Task:
     # long-lived clients, and we'll revise this if there are complaints
     TASK_TTL = timedelta(weeks=2)
 
-    def __init__(self, rc: StrictRedis, task_id: str, function_id: str = "", container: str = "", serializer: str = "", payload: str = "", task_group_id: str = ""):
+    def __init__(
+        self,
+        rc: StrictRedis,
+        task_id: str,
+        user_id: int = -1,
+        function_id: str = "",
+        container: str = "",
+        serializer: str = "",
+        payload: str = "",
+        task_group_id: str = ""
+    ):
         """ If the kwargs are passed, then they will be overwritten.  Otherwise, they will gotten from existing
         task entry.
         Parameters
@@ -117,6 +128,10 @@ class Task:
             Redis client so that properties can get get/set
         task_id : str
             UUID of task
+        user_id : int
+            ID of user that this task belongs to
+        function_id : str
+            UUID of function for task
         container : str
             UUID of container in which to run
         serializer : str
@@ -131,6 +146,9 @@ class Task:
 
         # If passed, we assume they should be set (i.e. in cases of new tasks)
         # if not passed, do not set
+        if user_id != -1:
+            self.user_id = user_id
+
         if function_id:
             self.function_id = function_id
 

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -159,7 +159,7 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
         "endpoint_id": endpoint_uuid,
         "task_transition": True
     }
-    app.logger.info(f"Task placed on queue for endpoint", extra=extra_logging)
+    app.logger.info("Task placed on queue for endpoint", extra=extra_logging)
 
     # increment the counter
     rc.incr('funcx_invocation_counter')

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -987,4 +987,4 @@ def get_batch_info(user: User, task_group_id):
     if task_group.user_id != user.id:
         return create_error_response(TaskGroupAccessForbidden(task_group_id), jsonify_response=True)
 
-    return jsonify({'authorized': True})
+    return jsonify({'user_id': user.id, 'authorized': True})

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -83,6 +83,13 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
        JSON response object, containing task_uuid, http_status_code, and success or error info
     """
     task_uuid = str(uuid.uuid4())
+    extra_logging = {
+        "user_id": user_id,
+        "task_id": task_uuid,
+        "task_group_id": task_group_id,
+        "endpoint_id": endpoint_uuid
+    }
+
     # Check if the user is allowed to access the function
     try:
         if not authorize_function(user_id, function_uuid, token):
@@ -115,7 +122,7 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
         res['task_uuid'] = task_uuid
         return res
 
-    app.logger.info(f"Got function container_uuid :{container_uuid}")
+    app.logger.info(f"Got function container_uuid :{container_uuid}", extra=extra_logging)
 
     # We should replace this with container_hdr = ";ctnr={container_uuid}"
     if not container_uuid:
@@ -150,7 +157,7 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
     task = Task(rc, task_uuid, container_uuid, serializer, payload, task_group_id)
 
     task_channel.put(endpoint_uuid, task)
-    app.logger.info(f"Task:{task_uuid} placed on queue for endpoint:{endpoint_uuid}")
+    app.logger.info(f"Task:{task_uuid} placed on queue for endpoint:{endpoint_uuid}", extra=extra_logging)
 
     # increment the counter
     rc.incr('funcx_invocation_counter')

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -148,7 +148,7 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
 
     # At this point the packed function body and the args are concatable strings
     payload = fn_code + input_data
-    task = Task(rc, task_uuid, container_uuid, serializer, payload, task_group_id)
+    task = Task(rc, task_uuid, function_uuid, container_uuid, serializer, payload, task_group_id)
 
     task_channel.put(endpoint_uuid, task)
 
@@ -156,10 +156,12 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
         "user_id": user_id,
         "task_id": task_uuid,
         "task_group_id": task_group_id,
+        "function_id": function_uuid,
         "endpoint_id": endpoint_uuid,
+        "container_id": container_uuid,
         "task_transition": True
     }
-    app.logger.info("Task placed on queue for endpoint", extra=extra_logging)
+    app.logger.info("received", extra=extra_logging)
 
     # increment the counter
     rc.incr('funcx_invocation_counter')
@@ -345,10 +347,12 @@ def status_and_result(user, task_id):
             "user_id": user.id,
             "task_id": task_id,
             "task_group_id": task.task_group_id,
+            "function_id": task.function_id,
             "endpoint_id": task.endpoint,
+            "container_id": task.container,
             "task_transition": True
         }
-        app.logger.info("Task queried by user completed", extra=extra_logging)
+        app.logger.info("complete", extra=extra_logging)
 
         task.delete()
 

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -148,7 +148,7 @@ def auth_and_launch(user_id, function_uuid, endpoint_uuid, input_data, app, toke
 
     # At this point the packed function body and the args are concatable strings
     payload = fn_code + input_data
-    task = Task(rc, task_uuid, function_uuid, container_uuid, serializer, payload, task_group_id)
+    task = Task(rc, task_uuid, user_id, function_uuid, container_uuid, serializer, payload, task_group_id)
 
     task_channel.put(endpoint_uuid, task)
 
@@ -344,7 +344,7 @@ def status_and_result(user, task_id):
     task_completion_t = task.completion_time
     if task_result or task_exception:
         extra_logging = {
-            "user_id": user.id,
+            "user_id": task.user_id,
             "task_id": task_id,
             "task_group_id": task.task_group_id,
             "function_id": task.function_id,
@@ -991,4 +991,4 @@ def get_batch_info(user: User, task_group_id):
     if task_group.user_id != user.id:
         return create_error_response(TaskGroupAccessForbidden(task_group_id), jsonify_response=True)
 
-    return jsonify({'user_id': user.id, 'authorized': True})
+    return jsonify({'authorized': True})

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -352,7 +352,7 @@ def status_and_result(user, task_id):
             "container_id": task.container,
             "task_transition": True
         }
-        app.logger.info("complete", extra=extra_logging)
+        app.logger.info("user_fetched", extra=extra_logging)
 
         task.delete()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ pyrsistent==0.16.0
 python-daemon==2.2.4
 python-dateutil==2.8.1
 python-engineio==3.13.0
+python-json-logger==2.0.1
 python-socketio==4.6.0
 pytz==2020.1
 pyzmq>=22.0.0


### PR DESCRIPTION
Clubhouse story: https://app.clubhouse.io/globus/story/8973/jsonify-logs-from-funcx-webservice

This logs all current logs now in JSON format as well. 2 key points now have additional log info - when task is submitted, and when task gets queried by user and is complete (The fields that are added are `user_id`, `task_id`, `task_group_id`, `endpoint_id`, etc.)

~A potential issue still remains where the original log still appears along with the JSON log~ (EDIT: this has been resolved)

![task_query_logs](https://user-images.githubusercontent.com/22580625/124319395-c6395200-db3f-11eb-8ac0-f3d471b31ee0.png)
