### PR TITLE
Update the auth function lookup to use function id rather than uuid

### DIFF
--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -196,7 +196,7 @@ def authorize_function(user_id, function_uuid, token):
 
     if not authorized:
         # Check if there are any groups associated with this function
-        groups = FunctionAuthGroup.find_by_function_uuid(function_uuid)
+        groups = FunctionAuthGroup.find_by_function_id(function.id)
         function_groups = [g.group_id for g in groups]
 
         if len(function_groups) > 0:

--- a/funcx_web_service/models/function.py
+++ b/funcx_web_service/models/function.py
@@ -73,5 +73,5 @@ class FunctionAuthGroup(db.Model):
     function = relationship("Function", back_populates='auth_groups')
 
     @classmethod
-    def find_by_function_uuid(cls, function_id):
+    def find_by_function_id(cls, function_id):
         return cls.query.filter_by(function_id=function_id).all()

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -204,7 +204,7 @@ class TestAuth(AppTestBase):
             return_value=True)
 
         mocker.patch.object(FunctionAuthGroup,
-                            "find_by_function_uuid",
+                            "find_by_function_id",
                             return_value=[
                                 FunctionAuthGroup(
                                     group_id="my-group",


### PR DESCRIPTION
Switches to using ID over UUID as the table was updated to no longer container uuids.