### PR TITLE
Restore full safety check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,7 @@ jobs:
     - name: Check for vulnerabilities in libraries
       run: |
         pip install safety
-        # The `-i 41002` can be removed when
-        # https://github.com/pyupio/safety-db/issues/2335
-        # is resolved
-        pip freeze | safety check -i 41002
+        pip freeze | safety check
     - name: Test with pytest
       run: |
         python -m coverage run -m pytest -r sx tests/


### PR DESCRIPTION
# Problem 
The [false-positive report for codecov](https://github.com/pyupio/safety-db/issues/2335) in the safety library has been resolved

# Approach
Removed the -i 41002