### PR TITLE
Use funcx_common for response_errors

### DIFF
--- a/funcx_web_service/authentication/auth.py
+++ b/funcx_web_service/authentication/auth.py
@@ -2,7 +2,11 @@ from funcx_web_service.models.auth_groups import AuthGroup
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.user import User
 from funcx_web_service.models.function import Function, FunctionAuthGroup
-from funcx.utils.response_errors import FunctionNotFound, EndpointNotFound, FunctionNotPermitted
+from funcx_common.response_errors import (
+    EndpointNotFound,
+    FunctionNotFound,
+    FunctionNotPermitted,
+)
 from flask import request, make_response, current_app as app
 import functools
 

--- a/funcx_web_service/error_responses.py
+++ b/funcx_web_service/error_responses.py
@@ -1,10 +1,9 @@
 from flask import jsonify
-
-from funcx.utils.response_errors import FuncxResponseError
+from funcx_common.response_errors import FuncxResponseError
 
 
 def create_error_response(exception, jsonify_response=False):
-    """ Creates JSON object responses for errors that occur in the service.
+    """Creates JSON object responses for errors that occur in the service.
     These responses can be sent back to the funcx SDK client to be decoded.
     They also have a "reason" property so that they are human-readable.
     Note that the returned JSON object will be a dict unless jsonify_response
@@ -32,11 +31,13 @@ def create_error_response(exception, jsonify_response=False):
         # if the error is not recognized as a FuncxResponseError, a generic
         # response of the same format will be sent back, indicating an
         # internal server error
-        response = {'status': 'Failed',
-                    'code': 0,
-                    'error_args': [],
-                    'reason': f'An unknown error occurred: {exception}',
-                    'http_status_code': 500}
+        response = {
+            "status": "Failed",
+            "code": 0,
+            "error_args": [],
+            "reason": f"An unknown error occurred: {exception}",
+            "http_status_code": 500,
+        }
         status_code = 500
 
     if jsonify_response:

--- a/funcx_web_service/errors.py
+++ b/funcx_web_service/errors.py
@@ -1,6 +1,6 @@
 class FuncxError(Exception):
     """ Base class for all web service exceptions not related to service responses
-    (for web service response exceptions, see: funcx.utils.response_errors)
+    (for web service response exceptions, see: funcx_common.response_errors)
     """
 
     def __init__(self, reason):

--- a/funcx_web_service/models/utils.py
+++ b/funcx_web_service/models/utils.py
@@ -3,9 +3,9 @@ import uuid
 
 import redis
 from flask import current_app as app
+from funcx_common.response_errors import FunctionNotFound, EndpointAlreadyRegistered
 
 from funcx_web_service.models import search
-from funcx.utils.response_errors import FunctionNotFound, EndpointAlreadyRegistered
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function
 from funcx_web_service.models.tasks import DBTask

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -21,11 +21,22 @@ from funcx_web_service.version import VERSION, MIN_SDK_VERSION
 from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
 from .redis_q import EndpointQueue
 
-from funcx.utils.response_errors import (UserNotFound, ContainerNotFound, TaskNotFound,
-                                         FunctionAccessForbidden, EndpointAccessForbidden,
-                                         ForwarderRegistrationError, EndpointStatsError,
-                                         RequestKeyError, RequestMalformed, InternalError,
-                                         EndpointOutdated, TaskGroupNotFound, TaskGroupAccessForbidden, InvalidUUID)
+from funcx_common.response_errors import (
+    UserNotFound,
+    ContainerNotFound,
+    TaskNotFound,
+    FunctionAccessForbidden,
+    EndpointAccessForbidden,
+    ForwarderRegistrationError,
+    EndpointStatsError,
+    RequestKeyError,
+    RequestMalformed,
+    InternalError,
+    EndpointOutdated,
+    TaskGroupNotFound,
+    TaskGroupAccessForbidden,
+    InvalidUUID
+)
 from funcx.sdk.version import VERSION as FUNCX_VERSION
 
 # Flask
@@ -213,7 +224,7 @@ def submit(user: User):
         serialize = post_req.get('serialize', None)
     except KeyError as e:
         # this should raise a 500 because it prevented any tasks from launching
-        raise RequestKeyError(e)
+        raise RequestKeyError(str(e))
 
     rc = g_redis_client()
     task_group = None
@@ -461,7 +472,7 @@ def reg_container(user: User):
         app.logger.info(f"Created container: {container_rec.container_uuid}")
         return jsonify({'container_id': container_rec.container_uuid})
     except KeyError as e:
-        raise RequestKeyError(e)
+        raise RequestKeyError(str(e))
 
     except Exception as e:
         raise InternalError(f'error adding container - {e}')
@@ -577,7 +588,7 @@ def reg_endpoint(user: User, user_uuid: str):
 
     except KeyError as e:
         app.logger.exception("Missing keys in json request")
-        raise RequestKeyError(e)
+        raise RequestKeyError(str(e))
 
     except UserNotFound as e:
         app.logger.exception("User not found")
@@ -719,7 +730,7 @@ def endpoint_whitelist(user: User, endpoint_id):
             post_req = request.json
             functions = post_req['func']
         except KeyError as e:
-            raise RequestKeyError(e)
+            raise RequestKeyError(str(e))
         except Exception as e:
             raise RequestMalformed(e)
         return add_ep_whitelist(user, endpoint_id, functions)
@@ -829,7 +840,7 @@ def reg_function(user: User, user_uuid):
 
     except KeyError as key_error:
         app.logger.error(key_error)
-        raise RequestKeyError(key_error)
+        raise RequestKeyError(str(key_error))
 
     except Exception as e:
         message = "Function registration failed for user:{} function_name:{} due to {}".\

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -670,7 +670,7 @@ def get_ep_stats(user: User, endpoint_id):
                 status['status'] = 'online'
 
     except Exception as e:
-        raise EndpointStatsError(endpoint_id, e)
+        raise EndpointStatsError(endpoint_id, str(e))
 
     return jsonify(status)
 
@@ -732,7 +732,7 @@ def endpoint_whitelist(user: User, endpoint_id):
         except KeyError as e:
             raise RequestKeyError(str(e))
         except Exception as e:
-            raise RequestMalformed(e)
+            raise RequestMalformed(str(e))
         return add_ep_whitelist(user, endpoint_id, functions)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ Flask-SocketIO==4.3.0
 flask-sqlalchemy
 Flask-Migrate==2.5.3
 Flask-WTF==0.14.3
-funcx_common==0.0.2
+funcx_common==0.0.3
 git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
 git+https://github.com/funcx-faas/funcx-forwarder.git@main#egg=funcx-forwarder
 globus-nexus-client==0.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Flask-SocketIO==4.3.0
 flask-sqlalchemy
 Flask-Migrate==2.5.3
 Flask-WTF==0.14.3
+funcx_common==0.0.2
 git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
 git+https://github.com/funcx-faas/funcx-forwarder.git@main#egg=funcx-forwarder
 globus-nexus-client==0.2.9

--- a/tests/routes/test_funcx.py
+++ b/tests/routes/test_funcx.py
@@ -1,4 +1,7 @@
+from unittest.mock import ANY
+
 import pytest
+from funcx_common.response_errors import ResponseErrorCode
 
 import funcx_web_service.authentication
 import funcx_web_service.models
@@ -8,9 +11,7 @@ from funcx_web_service.models.container import Container
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.function import Function, FunctionAuthGroup
 from funcx_web_service.models.user import User
-from funcx.utils.response_errors import ResponseErrorCode
 from tests.routes.app_test_base import AppTestBase
-from unittest.mock import ANY
 
 
 @pytest.fixture


### PR DESCRIPTION
Version 0.0.2 of funcx-common replaces the response_errors module from the funcx SDK. The first step towards eliminating that module is for upstream components depending on it to switch over to funcx-common.

Notable change: funcx-common has a stricter contract about the inputs to various error types and won't blindly stringify things. That means that KeyError exceptions being passed to the RequestKeyError constructor need to be explicitly stringified here.

I'm taking a guess at who should review this. @yadudoc reviewed @Loonride's recent PRs to add more extensive logging and update exception handling.

---

Aside: we should get more type coverage and `funcx-common` should start publishing its type annotation data. That will let us leverage mypy to catch issues like an incorrectly typed value being passed to an error initializer.