### PR TITLE
Disable the publish CI job on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
         codecov --token=${{ secrets.CODECOV_TOKEN }}
 
   publish:
+    if: ${{ github.repository == 'funcx-faas/funcx-web-service' }}
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,8 @@ jobs:
         codecov --token=${{ secrets.CODECOV_TOKEN }}
 
   publish:
-    if: ${{ github.repository == 'funcx-faas/funcx-web-service' }}
+    # only trigger on pushes to the main repo (not forks, and not PRs)
+    if: ${{ github.repository == 'funcx-faas/funcx-web-service' && github.event_name == 'push' }}
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The branch for this didn't run the publish job because the condition (repo must be the main repo) was not satisifed:
![image](https://user-images.githubusercontent.com/1300022/129798775-32569f56-09dc-4d78-a60f-3f577e370398.png)

@BenGalewsky, I think you were the one who setup the publish automation, so asking for your review.
I'll write this up in Clubhouse post-facto. It's near trivial; just resolving an annoyance I frequently deal with.