### PR TITLE
Sanitize access tokens in logs

### DIFF
--- a/funcx_web_service/models/search.py
+++ b/funcx_web_service/models/search.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict
 from flask import current_app as app
 from globus_sdk import AccessTokenAuthorizer, SearchClient, SearchAPIError
 
@@ -16,15 +17,22 @@ SEARCH_LIMIT = 10000
 DEFAULT_SEARCH_LIMIT = 10
 
 
+def _sanitize_tokens(token_data: Dict[str, Any]) -> Dict[str, Any]:
+    data_copy = token_data.copy()
+    if data_copy["access_token"] is not None:
+        data_copy["access_token"] = f"***{data_copy['access_token'][-5:]}"
+    if data_copy["refresh_token"] is not None:
+        data_copy["refresh_token"] = f"***{data_copy['refresh_token'][:-5:]}"
+    return data_copy
+
+
 def get_search_client():
     """Creates a Globus Search Client using FuncX's client token"""
     auth_client = funcx_web_service.authentication.auth.get_auth_client()
     tokens = auth_client.oauth2_client_credentials_tokens(requested_scopes=[SEARCH_SCOPE])
-    app.logger.debug(f"CC Tokens for Search: {tokens}")
     search_token = tokens.by_scopes[SEARCH_SCOPE]
-    app.logger.debug(f"Search token: {search_token}")
+    app.logger.debug(f"Search token: {_sanitize_tokens(search_token)}")
     access_token = search_token['access_token']
-    app.logger.debug("Access token")
     authorizer = AccessTokenAuthorizer(access_token)
     app.logger.debug("Acquired AccessTokenAuthorizer for search")
     search_client = SearchClient(authorizer)

--- a/funcx_web_service/models/search.py
+++ b/funcx_web_service/models/search.py
@@ -18,12 +18,19 @@ DEFAULT_SEARCH_LIMIT = 10
 
 
 def _sanitize_tokens(token_data: Dict[str, Any]) -> Dict[str, Any]:
-    data_copy = token_data.copy()
-    if data_copy["access_token"] is not None:
-        data_copy["access_token"] = f"***{data_copy['access_token'][-5:]}"
-    if data_copy["refresh_token"] is not None:
-        data_copy["refresh_token"] = f"***{data_copy['refresh_token'][:-5:]}"
-    return data_copy
+    access_token = token_data.get("access_token", "")
+    if access_token is not None:
+        access_token = f"***{token_data['access_token'][-5:]}"
+
+    refresh_token = token_data.get("refresh_token", "")
+    if refresh_token is not None:
+        refresh_token = f"***{token_data['refresh_token'][:-5:]}"
+
+    return {
+         "scope": token_data.get("scope"),
+         "access_token": access_token,
+         "refresh_token": refresh_token,
+    }
 
 
 def get_search_client():


### PR DESCRIPTION
When creating/updating a function or creating/updating an endpoint we create a `SearchClient` using `get_search_client` which logs the entire result of a OAuth2 Client Credentials grant -- which includes access/refresh tokens. We shouldn't log tokens to ensure that we're security risks via log output. This PR sanitizes the logged token output to obfuscate all but the last 5 characters in a token, which I think may end up being helpful in debugging authentication issues. The alternative was to remove the tokens altogether but I assumed that since we're logging them to begin with there was some value in at least being able to verify that the grant returned some token string.

Example old logs:
`{"asctime": "2021-09-22 17:39:15,065", "name": "funcx_web_service", "levelname": "DEBUG", "message": "Search token: {'scope': 'urn:globus:auth:scope:search.api.globus.org:all', 'access_token': 'AgpB5r0kg7pzvbWWvErOlyO....JPKkFX0jE20TVWdX', 'refresh_token': None, 'token_type': 'Bearer', 'expires_at_seconds': 1632505155, 'resource_server': 'search.api.globus.org'}"}`

Example new logs:
`{"asctime": "2021-09-23 16:06:13,076", "name": "funcx_web_service", "levelname": "DEBUG", "message": "Search token: {'scope': 'urn:globus:auth:scope:search.api.globus.org:all', 'access_token': '***cnjyk', 'refresh_token': None, 'token_type': 'Bearer', 'expires_at_seconds': 1632585973, 'resource_server': 'search.api.globus.org'}"}`

[sc-10615]