### PR TITLE
WIP Add container service and initial call in version endpoint

### DIFF
--- a/conf/app.conf.template
+++ b/conf/app.conf.template
@@ -3,3 +3,8 @@ REDIS_HOST = "localhost"
 
 GLOBUS_CLIENT = <<Globus Client ID>>
 GLOBUS_KEY = <<Globus Secret Key>>
+
+CONTAINER_SERVICE_ENABLED = False
+
+# URL of Container Service
+CONTAINER_SERVICE = http://localhost:5001

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -6,6 +6,7 @@ from flask import Flask, request
 from flask.logging import default_handler
 from pythonjsonlogger import jsonlogger
 
+from funcx_web_service.container_service_adapter import ContainerServiceAdapter
 from funcx_web_service.error_responses import create_error_response
 from funcx_web_service.response import FuncxResponse
 from funcx_web_service.routes.funcx import funcx_api
@@ -57,6 +58,17 @@ def create_app(test_config=None):
     else:
         application.config.from_envvar("APP_CONFIG_FILE")
         application.config.update(_override_config_with_environ(application))
+
+    if not hasattr(application, "extensions"):
+        application.extensions = {}
+
+    if application.config["CONTAINER_SERVICE_ENABLED"]:
+        container_service = ContainerServiceAdapter(
+            application.config["CONTAINER_SERVICE"]
+        )
+        application.extensions["ContainerService"] = container_service
+    else:
+        application.extensions["ContainerService"] = None
 
     # 100,000 Bytes is the max content length we will log for request/response JSON
     # due to the CloudWatch max log size

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -9,6 +9,7 @@ from pythonjsonlogger import jsonlogger
 from funcx_web_service.container_service_adapter import ContainerServiceAdapter
 from funcx_web_service.error_responses import create_error_response
 from funcx_web_service.response import FuncxResponse
+from funcx_web_service.routes.container import container_api
 from funcx_web_service.routes.funcx import funcx_api
 
 
@@ -169,6 +170,7 @@ def create_app(test_config=None):
 
     # Include the API blueprint
     application.register_blueprint(funcx_api, url_prefix="/v2")
+    application.register_blueprint(container_api, url_prefix="/v2")
     # Keeping these routes for backwards compatibility on tests.
     application.register_blueprint(funcx_api, url_prefix="/v1")
     application.register_blueprint(funcx_api, url_prefix="/api/v1")

--- a/funcx_web_service/container_service_adapter.py
+++ b/funcx_web_service/container_service_adapter.py
@@ -1,0 +1,15 @@
+from urllib.parse import urljoin
+
+import requests
+
+
+class ContainerServiceAdapter:
+    def __init__(self, service_url):
+        self.service_url = service_url
+
+    def get_version(self):
+        result = requests.get(urljoin(self.service_url, "version"))
+        if result.status_code == 200:
+            return result.json()
+        else:
+            return {"version": "Service Unavailable"}

--- a/funcx_web_service/routes/container.py
+++ b/funcx_web_service/routes/container.py
@@ -1,0 +1,89 @@
+import uuid
+
+from flask import Blueprint
+from flask import current_app as app
+from flask import jsonify, request
+from funcx_common.response_errors import InternalError, RequestKeyError
+
+from funcx_web_service.authentication.auth import authenticated
+
+from ..models.container import Container, ContainerImage
+from ..models.user import User
+
+container_api = Blueprint("container_routes", __name__)
+
+
+@container_api.route("/containers/<container_id>/<container_type>", methods=["GET"])
+@authenticated
+def get_cont(user: User, container_id, container_type):
+    """Get the details of a container.
+
+    Parameters
+    ----------
+    user : User
+        The primary identity of the user
+    container_id : str
+        The id of the container
+    container_type : str
+        The type of containers to return: Docker, Singularity, Shifter, etc.
+
+    Returns
+    -------
+    dict
+        A dictionary of container details
+    """
+
+    app.logger.info(f"Getting container details: {container_id}")
+    container = Container.find_by_uuid_and_type(container_id, container_type)
+    app.logger.info(f"Got container: {container}")
+    return jsonify({"container": container.to_json()})
+
+
+@container_api.route("/containers", methods=["POST"])
+@authenticated
+def reg_container(user: User):
+    """Register a new container.
+
+    Parameters
+    ----------
+    user : User
+        The primary identity of the user
+
+    JSON Body
+    ---------
+        name: Str
+        description: Str
+        type: The type of containers that will be used (Singularity, Shifter, Docker)
+        location:  The location of the container (e.g., its docker url).
+
+    Returns
+    -------
+    dict
+        A dictionary of container details including its uuid
+    """
+
+    app.logger.debug("Creating container.")
+    post_req = request.json
+
+    try:
+        container_rec = Container(
+            author=user.id,
+            name=post_req["name"],
+            description=None
+            if not post_req["description"]
+            else post_req["description"],
+            container_uuid=str(uuid.uuid4()),
+        )
+        container_rec.images = [
+            ContainerImage(type=post_req["type"], location=post_req["location"])
+        ]
+
+        container_rec.save_to_db()
+
+        app.logger.info(f"Created container: {container_rec.container_uuid}")
+        return jsonify({"container_id": container_rec.container_uuid})
+    except KeyError as e:
+        raise RequestKeyError(str(e))
+
+    except Exception as e:
+        raise InternalError(f"error adding container - {e}")

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -575,14 +575,18 @@ def get_version():
         return jsonify(forwarder_version)
 
     if s == "all":
-        return jsonify(
-            {
-                "api": VERSION,
-                "forwarder": forwarder_version,
-                "min_sdk_version": MIN_SDK_VERSION,
-                "min_ep_version": min_ep_version,
-            }
-        )
+        result = {
+            "api": VERSION,
+            "forwarder": forwarder_version,
+            "min_sdk_version": MIN_SDK_VERSION,
+            "min_ep_version": min_ep_version,
+        }
+
+        if app.extensions["ContainerService"]:
+            result["container_service"] = app.extensions[
+                "ContainerService"
+            ].get_version()["version"]
+        return jsonify(result)
 
     raise RequestMalformed("unknown service type or other error.")
 

--- a/tests/routes/app_test_base.py
+++ b/tests/routes/app_test_base.py
@@ -2,18 +2,20 @@ from funcx_web_service import create_app
 
 
 class AppTestBase:
-    def test_client(self):
-        app = create_app(
-            test_config={
-                "REDIS_HOST": "localhost",
-                "REDIS_PORT": 5000,
-                "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-                "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-                "HOSTNAME": "http://testhost",
-                "FORWARDER_IP": "192.162.3.5",
-                "ADVERTISED_REDIS_HOST": "my-redis.com",
-            }
-        )
+    def test_client(self, extra_config=None):
+        test_config = {
+            "REDIS_HOST": "localhost",
+            "REDIS_PORT": 5000,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+            "HOSTNAME": "http://testhost",
+            "FORWARDER_IP": "192.162.3.5",
+            "ADVERTISED_REDIS_HOST": "my-redis.com",
+            "CONTAINER_SERVICE_ENABLED": False,
+        }
+
+        test_config.update(extra_config if extra_config else {})
+        app = create_app(test_config=test_config)
         app.secret_key = "Shhhhh"
         return app.test_client()
 

--- a/tests/routes/test_register_container.py
+++ b/tests/routes/test_register_container.py
@@ -8,7 +8,7 @@ class TestRegisterContainer(AppTestBase):
     def test_register_container(self, mocker, mock_auth_client):
         client = self.client
         result = client.post(
-            "api/v1/containers",
+            "v2/containers",
             json={
                 "name": "myContainer",
                 "function_name": "test fun",
@@ -36,7 +36,7 @@ class TestRegisterContainer(AppTestBase):
     def test_register_container_invalid_spec(self, mocker, mock_auth_client):
         client = self.client
         result = client.post(
-            "api/v1/containers",
+            "v2/containers",
             json={
                 "type": "docker",
                 "location": "http://hub.docker.com/myContainer",
@@ -58,7 +58,7 @@ class TestRegisterContainer(AppTestBase):
 
         client = self.client
         result = client.get(
-            "api/v1/containers/1/docker", headers={"Authorization": "my_token"}
+            "v2/containers/1/docker", headers={"Authorization": "my_token"}
         )
 
         result_container = result.json["container"]

--- a/tests/test.config
+++ b/tests/test.config
@@ -1,3 +1,4 @@
 FOO = "bar"
 SECRET_VALUE = "blah"
 BOOL_VALUE = False
+CONTAINER_SERVICE_ENABLED = False

--- a/tests/test_container_service_adapter.py
+++ b/tests/test_container_service_adapter.py
@@ -1,0 +1,24 @@
+import responses
+
+from funcx_web_service import ContainerServiceAdapter
+
+
+class TestContainerServiceAdapter:
+    @responses.activate
+    def test_version(self):
+        responses.add(
+            responses.GET,
+            "http://container-service:5000/version",
+            json={"version": "3.14"},
+            status=200,
+        )
+        container_service = ContainerServiceAdapter("http://container-service:5000")
+        assert container_service.get_version() == {"version": "3.14"}
+
+    @responses.activate
+    def test_version_server_error(self):
+        responses.add(
+            responses.GET, "http://container-service:5000/version", status=500
+        )
+        container_service = ContainerServiceAdapter("http://container-service:5000")
+        assert container_service.get_version() == {"version": "Service Unavailable"}


### PR DESCRIPTION
As part of deployment of container service with helm chart. Partial solution to [Container Service Issue 10](https://github.com/funcx-faas/funcx-container-service/issues/10)

# Approach
1. Add config settings for the container service
2. Add a ContainerServiceAdaptor
3. Use the adaptor to fetch the version from the Container Service

The version info will require [ContainerService Version Endpoint](https://github.com/funcx-faas/funcx-container-service/issues/14) to be implemented 
