### PR TITLE
Update to the latest funcx-common and adapt usage

### DIFF
--- a/funcx_web_service/models/tasks.py
+++ b/funcx_web_service/models/tasks.py
@@ -61,6 +61,9 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     container = RedisField()
     payload = RedisField(serde=JSON_SERDE)
     result = RedisField()
+    result_reference = t.cast(
+        t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
+    )
     exception = RedisField()
     completion_time = RedisField()
     task_group_id = RedisField()

--- a/requirements.in
+++ b/requirements.in
@@ -26,7 +26,7 @@ psycopg2-binary==2.8.5
 redis==3.5.3
 
 # funcx tools
-funcx_common[redis]==0.0.6
+funcx_common[redis]==0.0.9
 
 # globus clients
 globus-nexus-client==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.15.0
 charset-normalizer==2.0.7
 click==8.0.3
 cryptography==35.0.0
-funcx-common==0.0.8
+funcx-common==0.0.9
 globus-nexus-client==0.3.0
 globus-sdk==2.0.1
 greenlet==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.15.0
 charset-normalizer==2.0.7
 click==8.0.3
 cryptography==35.0.0
-funcx-common==0.0.6
+funcx-common==0.0.8
 globus-nexus-client==0.3.0
 globus-sdk==2.0.1
 greenlet==1.1.2


### PR DESCRIPTION
The change from taking hostname/port information to taking a redis URL requires that the we plan for the future and format a redis URL with the current config variables.

In the future, it should be possible to switch from from REDIS_HOST/REDIS_PORT to having no configuration of the redis connection handled directly by the webapp, and instead rely on the default connection building being controllable via the FUNCX_COMMON_REDIS_URL environment variable.
For this reason, a TODO comment is added which notes the removal of these parameters from flask config.

Before this can be done, deployment logic in the helm charts needs to be updated to set a redis URL via the env var there. If this is done at the same time that the flask config variables are removed, the application should "switch" between configuration modes.
Afterwards, support for these values in the application here can be removed.