### PR TITLE
Refactor to use the AuthenticationState pattern and make authentication code controllable and testable

### DIFF
--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -8,6 +8,7 @@ from pythonjsonlogger import jsonlogger
 
 from funcx_web_service.container_service_adapter import ContainerServiceAdapter
 from funcx_web_service.error_responses import create_error_response
+from funcx_web_service.models import db, load_all_models
 from funcx_web_service.response import FuncxResponse
 from funcx_web_service.routes.container import container_api
 from funcx_web_service.routes.funcx import funcx_api
@@ -75,15 +76,11 @@ def create_app(test_config=None):
     # due to the CloudWatch max log size
     max_log_content_length = 100000
 
+    load_all_models()
+    db.init_app(application)
+
     @application.before_first_request
     def create_tables():
-        import funcx_web_service.models.auth_groups  # NOQA F401
-        import funcx_web_service.models.container  # NOQA F401
-        import funcx_web_service.models.function  # NOQA F401
-        import funcx_web_service.models.user  # NOQA F401
-        from funcx_web_service.models import db
-
-        db.init_app(application)
         db.create_all()
 
     # this is called before every request

--- a/funcx_web_service/authentication/auth_state.py
+++ b/funcx_web_service/authentication/auth_state.py
@@ -68,9 +68,17 @@ class AuthenticationState:
         if not self.is_authenticated:
             abort(401, "method requires token authenticated access")
 
-    # TODO: determine if a 403 response is appropriate for incorrect scopes
-    # this should possibly be changed to a 401
     def assert_has_scope(self, scope: str) -> None:
+        # the user may be thought of as "not properly authorized" if they do not have
+        # required scopes
+        # this leaves a question of whether this should be a 401 (Unauthorized) or
+        # 403 (Forbidden)
+        #
+        # the answer is that it must be a 403
+        # this requirement is set by the OAuth2 spec
+        #
+        # for more detail, see
+        #   https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
         if scope not in self.scopes:
             abort(403, "Missing Scopes")
 

--- a/funcx_web_service/authentication/auth_state.py
+++ b/funcx_web_service/authentication/auth_state.py
@@ -68,6 +68,8 @@ class AuthenticationState:
         if not self.is_authenticated:
             abort(401, "method requires token authenticated access")
 
+    # TODO: determine if a 403 response is appropriate for incorrect scopes
+    # this should possibly be changed to a 401
     def assert_has_scope(self, scope: str) -> None:
         if scope not in self.scopes:
             abort(403, "Missing Scopes")

--- a/funcx_web_service/authentication/auth_state.py
+++ b/funcx_web_service/authentication/auth_state.py
@@ -43,7 +43,7 @@ class AuthenticationState:
         if token:
             self._handle_token()
 
-    def _handle_token(self, token: str) -> None:
+    def _handle_token(self) -> None:
         """Given a token, flesh out the AuthenticationState."""
         self.introspect_data = introspect_token(self.token)
         self.username = self.introspect_data["username"]
@@ -56,13 +56,6 @@ class AuthenticationState:
             self._user_object = User.resolve_user(self.username)
         return self._user_object
 
-    def assert_has_scope(self, scope: str) -> None:
-        if scope not in self.scopes:
-            abort(403, "Missing Scopes")
-
-    def assert_has_default_scope(self) -> None:
-        self.assert_has_scope(self.funcx_all_scope)
-
     @property
     def is_authenticated(self):
         return self.identity_id is not None
@@ -74,6 +67,13 @@ class AuthenticationState:
         """
         if not self.is_authenticated:
             abort(401, "method requires token authenticated access")
+
+    def assert_has_scope(self, scope: str) -> None:
+        if scope not in self.scopes:
+            abort(403, "Missing Scopes")
+
+    def assert_has_default_scope(self) -> None:
+        self.assert_has_scope(self.funcx_all_scope)
 
 
 def get_auth_state():

--- a/funcx_web_service/authentication/auth_state.py
+++ b/funcx_web_service/authentication/auth_state.py
@@ -45,7 +45,7 @@ class AuthenticationState:
 
     def _handle_token(self) -> None:
         """Given a token, flesh out the AuthenticationState."""
-        self.introspect_data = introspect_token(self.token)
+        self.introspect_data = introspect_token(t.cast(str, self.token))
         self.username = self.introspect_data["username"]
         self.identity_id = self.introspect_data["sub"]
         self.scopes = set(self.introspect_data["scope"].split(" "))

--- a/funcx_web_service/authentication/auth_state.py
+++ b/funcx_web_service/authentication/auth_state.py
@@ -1,0 +1,96 @@
+import typing as t
+
+import globus_sdk
+from flask import abort, current_app, g, request
+
+from funcx_web_service.models.user import User
+
+from .globus_auth import introspect_token
+
+
+class AuthenticationState:
+    """
+    This is a dedicated object for handling authentication.
+
+    It takes in a Globus Auth token and resolve it to a user and various data about that
+    user. It is the "auth_state" object for the application within the context of a
+    request, showing "who" is calling the application (e.g. identity_id) and some
+    information about "how" the call is being made (e.g. scopes).
+
+    For the most part, this should not handle authorization checks, to maintain
+    separation of concerns.
+    """
+
+    # Default scope if not provided in config
+    DEFAULT_FUNCX_SCOPE = (
+        "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
+    )
+
+    def __init__(
+        self, token: t.Optional[str], *, assert_default_scope: bool = True
+    ) -> None:
+        self.funcx_all_scope: str = current_app.config.get(
+            "FUNCX_SCOPE", self.DEFAULT_FUNCX_SCOPE
+        )
+        self.token = token
+
+        self.introspect_data: t.Optional[globus_sdk.GlobusHTTPResponse] = None
+        self.identity_id: t.Optional[str] = None
+        self.username: t.Optional[str] = None
+        self._user_object: t.Optional[User] = None
+        self.scopes: t.Set[str] = set()
+
+        if token:
+            self._handle_token()
+
+    def _handle_token(self, token: str) -> None:
+        """Given a token, flesh out the AuthenticationState."""
+        self.introspect_data = introspect_token(self.token)
+        self.username = self.introspect_data["username"]
+        self.identity_id = self.introspect_data["sub"]
+        self.scopes = set(self.introspect_data["scope"].split(" "))
+
+    @property
+    def user_object(self) -> User:
+        if self._user_object is None:
+            self._user_object = User.resolve_user(self.username)
+        return self._user_object
+
+    def assert_has_scope(self, scope: str) -> None:
+        if scope not in self.scopes:
+            abort(403, "Missing Scopes")
+
+    def assert_has_default_scope(self) -> None:
+        self.assert_has_scope(self.funcx_all_scope)
+
+    @property
+    def is_authenticated(self):
+        return self.identity_id is not None
+
+    def assert_is_authenticated(self):
+        """
+        This tests that is_authenticated=True, and raises an Unauthorized error
+        (401) if it is not.
+        """
+        if not self.is_authenticated:
+            abort(401, "method requires token authenticated access")
+
+
+def get_auth_state():
+    """
+    Get the current AuthenticationState. This may be called at any time in the
+    application within a request context, but will always return the same state object.
+
+    It is especially useful for tests, which can mock over the return value of this
+    function by setting `g.auth_state` and be assured that the application will respect
+    the fake authentication info.
+    """
+    if not g.get("auth_state", None):
+        cred = request.headers.get("Authorization", None)
+        if cred and cred.startswith("Bearer "):
+            cred = cred[7:]
+        else:
+            cred = None
+
+        g.auth_state = AuthenticationState(cred)
+    return g.auth_state

--- a/funcx_web_service/authentication/globus_auth.py
+++ b/funcx_web_service/authentication/globus_auth.py
@@ -1,0 +1,22 @@
+import globus_sdk
+from flask import abort, current_app
+
+
+def introspect_token(
+    token: str, *, verify: bool = True
+) -> globus_sdk.GlobusHTTPResponse:
+    client = get_auth_client()
+    data = client.oauth2_token_introspect(token)
+    if verify:
+        if not data.get("active", False):
+            abort(401, "Credentials are inactive.")
+    return data
+
+
+# FIXME:
+# this should be only creating a single client per web worker, not a new one per call
+def get_auth_client():
+    """Create an AuthClient for the service."""
+    return globus_sdk.ConfidentialAppAuthClient(
+        current_app.config["GLOBUS_CLIENT"], current_app.config["GLOBUS_KEY"]
+    )

--- a/funcx_web_service/models/__init__.py
+++ b/funcx_web_service/models/__init__.py
@@ -1,3 +1,8 @@
 from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
+
+
+def load_all_models():
+    # deferred import of the necessary model code
+    from . import auth_groups, container, function, user  # noqa: F401

--- a/funcx_web_service/models/__init__.py
+++ b/funcx_web_service/models/__init__.py
@@ -1,6 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 
-db = SQLAlchemy()
+db: SQLAlchemy = SQLAlchemy()
 
 
 def load_all_models():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 import responses
 
 from funcx_web_service import create_app
+from funcx_web_service.models import db
 from funcx_web_service.models.user import User
 
 TEST_FORWARDER_IP = "192.162.3.5"
@@ -108,6 +109,11 @@ def flask_app():
         }
     )
     app.secret_key = "Shhhhh"
+
+    # do DB setup without waiting for first request, so that tests can use the DB
+    # outside of a request context
+    with app.test_request_context():
+        db.create_all()
     return app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,8 @@ def mock_redis(mocker, mock_redis_server):
 def flask_app():
     app = create_app(
         test_config={
+            "GLOBUS_CLIENT": "TEST_GLOBUS_CLIENT_ID",
+            "GLOBUS_KEY": "TEST_GLOBUS_CLIENT_SECRET",
             "REDIS_HOST": "localhost",
             "REDIS_PORT": 5000,
             "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",

--- a/tests/integration/test_endpoint_api.py
+++ b/tests/integration/test_endpoint_api.py
@@ -1,0 +1,32 @@
+import uuid
+
+from funcx_web_service.models.user import User
+
+
+def test_unauthorized_get_ep_status(
+    flask_test_client, mock_auth_state, default_forwarder_responses
+):
+    """
+    Create (register) an endpoint as one user, then switch to a second user and attempt
+    to get the endpoint status.
+
+    The result should be an error.
+    """
+    id1 = str(uuid.uuid1())
+    id2 = str(uuid.uuid1())
+    epid = str(uuid.uuid1())
+    epinfo = {
+        "version": "100.0.0",
+        "endpoint_name": "foo-ep-1",
+        "endpoint_uuid": epid,
+    }
+
+    user1 = User(username="foo", globus_identity=id1, id=100)
+    user2 = User(username="bar", globus_identity=id2, id=101)
+
+    with mock_auth_state(user=user1):
+        result = flask_test_client.post("/api/v1/endpoints", json=epinfo)
+        assert result.status_code == 200
+    with mock_auth_state(user=user2):
+        result2 = flask_test_client.get(f"/api/v1/endpoints/{epid}/status")
+        assert result2.status_code == 403

--- a/tests/unit/auth/test_auth_state.py
+++ b/tests/unit/auth/test_auth_state.py
@@ -1,10 +1,12 @@
 import pytest
 import responses
+from werkzeug.exceptions import Forbidden, Unauthorized
 
 from funcx_web_service.authentication.auth_state import (
     AuthenticationState,
     get_auth_state,
 )
+from funcx_web_service.models.user import User
 
 INTROSPECT_RESPONSE = {
     "active": True,
@@ -33,23 +35,42 @@ def good_introspect(mocked_responses):
     )
 
 
-def test_get_auth_state_no_authz_header(flask_app, flask_app_ctx):
-    ctx = flask_app.test_request_context(
-        headers={},  # no Authorization header
+@pytest.fixture
+def badscope_introspect(mocked_responses):
+    data = {**INTROSPECT_RESPONSE}
+    data["scope"] = ""
+    mocked_responses.add(
+        responses.POST,
+        "https://auth.globus.org/v2/oauth2/token/introspect",
+        json=data,
+        status=200,
     )
 
+
+def test_get_auth_state_no_authz_header(flask_app, flask_app_ctx):
+    # this test uses a customized flask request context in order to test get_auth_state
+    # codepaths
+    # this generally is not necessary to imitate: simply construct an
+    # AuthenticationState in tests instead
+    ctx = flask_app.test_request_context(headers={})
     ctx.push()
 
     state = get_auth_state()
     assert isinstance(state, AuthenticationState)
     assert state.is_authenticated is False
 
+    with pytest.raises(Unauthorized):
+        state.assert_is_authenticated()
+
     ctx.pop()
 
 
 def test_get_auth_state_good_token(flask_app, flask_app_ctx, good_introspect):
+    # this test uses a customized flask request context in order to test get_auth_state
+    # codepaths
+    # this generally is not necessary to imitate: simply construct an
+    # AuthenticationState in tests instead
     ctx = flask_app.test_request_context(headers={"Authorization": "Bearer foo"})
-
     ctx.push()
 
     state = get_auth_state()
@@ -58,6 +79,30 @@ def test_get_auth_state_good_token(flask_app, flask_app_ctx, good_introspect):
 
     assert state.username == INTROSPECT_RESPONSE["username"]
     assert state.identity_id == INTROSPECT_RESPONSE["sub"]
+
+    state.assert_is_authenticated()
     state.assert_has_default_scope()
 
     ctx.pop()
+
+
+def test_auth_state_bad_scope(flask_request_ctx, badscope_introspect):
+    state = AuthenticationState("foo")
+    assert isinstance(state, AuthenticationState)
+    assert state.is_authenticated is True
+    assert state.username == INTROSPECT_RESPONSE["username"]
+    assert state.identity_id == INTROSPECT_RESPONSE["sub"]
+
+    # TODO: is this right? seems like this should be a class of 401
+    with pytest.raises(Forbidden):
+        state.assert_has_default_scope()
+
+
+def test_auth_state_user_object(flask_request_ctx, good_introspect):
+    # check that fetching a user object from the AuthenticationState works
+    state = AuthenticationState("foo")
+
+    userobj = state.user_object
+    assert userobj is not None
+    assert isinstance(userobj, User)
+    assert userobj.username == state.username

--- a/tests/unit/auth/test_auth_state.py
+++ b/tests/unit/auth/test_auth_state.py
@@ -1,0 +1,63 @@
+import pytest
+import responses
+
+from funcx_web_service.authentication.auth_state import (
+    AuthenticationState,
+    get_auth_state,
+)
+
+INTROSPECT_RESPONSE = {
+    "active": True,
+    "scope": "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
+    "sub": "79cb54bb-2296-424a-9ab2-8dabcf1457ff",
+    "username": "example@globus.org",
+    "name": None,
+    "email": None,
+    "client_id": "facd7ccc-c5f4-42aa-916b-a0e270e2c2a9",
+    "aud": ["facd7ccc-c5f4-42aa-916b-a0e270e2c2a9"],
+    "iss": "https://auth.globus.org",
+    "exp": 1915236549,
+    "iat": 1599703671,
+    "nbf": 1599703671,
+    "identity_set": ["79cb54bb-2296-424a-9ab2-8dabcf1457ff"],
+}
+
+
+@pytest.fixture
+def good_introspect(mocked_responses):
+    mocked_responses.add(
+        responses.POST,
+        "https://auth.globus.org/v2/oauth2/token/introspect",
+        json=INTROSPECT_RESPONSE,
+        status=200,
+    )
+
+
+def test_get_auth_state_no_authz_header(flask_app, flask_app_ctx):
+    ctx = flask_app.test_request_context(
+        headers={},  # no Authorization header
+    )
+
+    ctx.push()
+
+    state = get_auth_state()
+    assert isinstance(state, AuthenticationState)
+    assert state.is_authenticated is False
+
+    ctx.pop()
+
+
+def test_get_auth_state_good_token(flask_app, flask_app_ctx, good_introspect):
+    ctx = flask_app.test_request_context(headers={"Authorization": "Bearer foo"})
+
+    ctx.push()
+
+    state = get_auth_state()
+    assert isinstance(state, AuthenticationState)
+    assert state.is_authenticated is True
+
+    assert state.username == INTROSPECT_RESPONSE["username"]
+    assert state.identity_id == INTROSPECT_RESPONSE["sub"]
+    state.assert_has_default_scope()
+
+    ctx.pop()

--- a/tests/unit/routes/conftest.py
+++ b/tests/unit/routes/conftest.py
@@ -1,36 +1,9 @@
 import pytest
 from funcx_common.tasks import TaskState
 
-import funcx_web_service
 from funcx_web_service.models.endpoint import Endpoint
 from funcx_web_service.models.tasks import InternalTaskState, RedisTask
 from funcx_web_service.models.user import User
-
-
-@pytest.fixture
-def mock_auth_client(mocker, mock_user):
-    mock_auth_client = mocker.Mock()
-    mock_auth_client.oauth2_token_introspect = mocker.Mock(
-        return_value={
-            "username": "bob",
-            "sub": "123-456",
-            "active": True,
-            "scope": "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",  # noqa: E501
-        }
-    )
-
-    mocker.patch.object(
-        funcx_web_service.authentication.auth,
-        "get_auth_client",
-        return_value=mock_auth_client,
-    )
-
-    mocker.patch(
-        "funcx_web_service.authentication.auth.User.resolve_user",
-        return_value=mock_user,
-    )
-
-    return mock_auth_client
 
 
 @pytest.fixture

--- a/tests/unit/routes/test_auth.py
+++ b/tests/unit/routes/test_auth.py
@@ -1,5 +1,3 @@
-def test_authenticate(flask_test_client, mock_auth_client):
-    result = flask_test_client.get(
-        "/api/v1/authenticate", headers={"Authorization": "my_token"}
-    )
+def test_authenticate(flask_test_client, in_mock_auth_state):
+    result = flask_test_client.get("/api/v1/authenticate")
     assert result.status_code == 200

--- a/tests/unit/routes/test_register_container.py
+++ b/tests/unit/routes/test_register_container.py
@@ -3,7 +3,7 @@ from funcx_common.response_errors import ResponseErrorCode
 from funcx_web_service.models.container import Container
 
 
-def test_register_container(flask_test_client, mocker, mock_auth_client):
+def test_register_container(flask_test_client, mocker, in_mock_auth_state):
     result = flask_test_client.post(
         "v2/containers",
         json={
@@ -31,7 +31,7 @@ def test_register_container(flask_test_client, mocker, mock_auth_client):
     assert saved_container.images[0].location == "http://hub.docker.com/myContainer"
 
 
-def test_register_container_invalid_spec(flask_test_client, mocker, mock_auth_client):
+def test_register_container_invalid_spec(flask_test_client, mocker, in_mock_auth_state):
     result = flask_test_client.post(
         "v2/containers",
         json={
@@ -46,7 +46,7 @@ def test_register_container_invalid_spec(flask_test_client, mocker, mock_auth_cl
     assert result.json["reason"] == "Missing key in JSON request - 'name'"
 
 
-def test_get_container(flask_test_client, mocker, mock_auth_client):
+def test_get_container(flask_test_client, mocker, in_mock_auth_state):
     container = Container()
     container.container_uuid = "123-45-678"
     container.name = "Docky"

--- a/tests/unit/routes/test_register_endpoint.py
+++ b/tests/unit/routes/test_register_endpoint.py
@@ -8,7 +8,7 @@ from funcx_web_service.models.endpoint import Endpoint
 
 
 @responses.activate
-def test_register_endpoint(flask_test_client, mocker, mock_auth_client, mock_user):
+def test_register_endpoint(flask_test_client, mocker, in_mock_auth_state, mock_user):
     responses.add(
         responses.GET,
         "http://192.162.3.5:8080/version",
@@ -55,7 +55,7 @@ def test_register_endpoint(flask_test_client, mocker, mock_auth_client, mock_use
 
 
 def test_register_endpoint_version_mismatch(
-    flask_test_client, mocker, mock_auth_client
+    flask_test_client, mocker, in_mock_auth_state
 ):
     get_forwarder_version = mocker.patch(
         "funcx_web_service.routes.funcx.get_forwarder_version",
@@ -74,7 +74,7 @@ def test_register_endpoint_version_mismatch(
     assert "Endpoint is out of date." in result.json["reason"]
 
 
-def test_register_endpoint_no_version(flask_test_client, mocker, mock_auth_client):
+def test_register_endpoint_no_version(flask_test_client, mocker, in_mock_auth_state):
     get_forwarder_version = mocker.patch(
         "funcx_web_service.routes.funcx.get_forwarder_version",
         return_value={"min_ep_version": "1.42.0"},
@@ -90,7 +90,7 @@ def test_register_endpoint_no_version(flask_test_client, mocker, mock_auth_clien
     assert "version must be passed in" in result.json["reason"]
 
 
-def test_register_endpoint_missing_keys(flask_test_client, mocker, mock_auth_client):
+def test_register_endpoint_missing_keys(flask_test_client, mocker, in_mock_auth_state):
     get_forwarder_version = mocker.patch(
         "funcx_web_service.routes.funcx.get_forwarder_version",
         return_value={"min_ep_version": "1.0.0"},
@@ -110,7 +110,7 @@ def test_register_endpoint_missing_keys(flask_test_client, mocker, mock_auth_cli
 
 
 def test_register_endpoint_already_registered(
-    flask_test_client, mocker, mock_auth_client, mock_endpoint
+    flask_test_client, mocker, in_mock_auth_state, mock_endpoint
 ):
     get_forwarder_version = mocker.patch(
         "funcx_web_service.routes.funcx.get_forwarder_version",
@@ -139,7 +139,7 @@ def test_register_endpoint_already_registered(
     )
 
 
-def test_register_endpoint_unknown_error(flask_test_client, mocker, mock_auth_client):
+def test_register_endpoint_unknown_error(flask_test_client, mocker, in_mock_auth_state):
     get_forwarder_version = mocker.patch(
         "funcx_web_service.routes.funcx.get_forwarder_version",
         return_value={"min_ep_version": "1.0.0"},
@@ -168,7 +168,7 @@ def test_register_endpoint_unknown_error(flask_test_client, mocker, mock_auth_cl
     assert result.json["reason"] == "An unknown error occurred: hello"
 
 
-def test_endpoint_status(flask_test_client, mocker, mock_auth_client, mock_redis):
+def test_endpoint_status(flask_test_client, mocker, in_mock_auth_state, mock_redis):
     mocker.patch("funcx_web_service.routes.funcx.authorize_endpoint", return_value=True)
 
     epid = 123
@@ -184,7 +184,7 @@ def test_endpoint_status(flask_test_client, mocker, mock_auth_client, mock_redis
     lrange_spy.assert_called_with("ep_status_123", 0, 1)
 
 
-def test_endpoint_delete(flask_test_client, mocker, mock_auth_client, mock_user):
+def test_endpoint_delete(flask_test_client, mocker, in_mock_auth_state, mock_user):
     mock_delete_endpoint = mocker.patch.object(
         Endpoint, "delete_endpoint", return_value="Ok"
     )
@@ -196,7 +196,7 @@ def test_endpoint_delete(flask_test_client, mocker, mock_auth_client, mock_user)
     mock_delete_endpoint.assert_called_with(mock_user, "123")
 
 
-def test_get_whitelist(flask_test_client, mocker, mock_auth_client, mock_user):
+def test_get_whitelist(flask_test_client, mocker, in_mock_auth_state, mock_user):
     get_ep_whitelist = mocker.patch(
         "funcx_web_service.routes.funcx.get_ep_whitelist",
         return_value={"status": "success", "functions": ["1", "2", "3"]},
@@ -211,7 +211,7 @@ def test_get_whitelist(flask_test_client, mocker, mock_auth_client, mock_user):
     get_ep_whitelist.assert_called_with(mock_user, "123")
 
 
-def test_add_whitelist(flask_test_client, mocker, mock_auth_client, mock_user):
+def test_add_whitelist(flask_test_client, mocker, in_mock_auth_state, mock_user):
     add_ep_whitelist = mocker.patch(
         "funcx_web_service.routes.funcx.add_ep_whitelist",
         return_value={"status": "success"},
@@ -227,7 +227,7 @@ def test_add_whitelist(flask_test_client, mocker, mock_auth_client, mock_user):
     add_ep_whitelist.assert_called_with(mock_user, "123", ["1", "2", "3"])
 
 
-def test_delete_whitelisted(flask_test_client, mocker, mock_auth_client, mock_user):
+def test_delete_whitelisted(flask_test_client, mocker, in_mock_auth_state, mock_user):
     delete_ep_whitelist = mocker.patch(
         "funcx_web_service.routes.funcx.delete_ep_whitelist",
         return_value={"status": "success"},

--- a/tests/unit/routes/test_register_function.py
+++ b/tests/unit/routes/test_register_function.py
@@ -5,7 +5,7 @@ from funcx_web_service.models.function import Function, FunctionAuthGroup
 from funcx_web_service.models.user import User
 
 
-def test_register_function(flask_test_client, mock_auth_client, mocker):
+def test_register_function(flask_test_client, in_mock_auth_state, mocker):
     mock_ingest = mocker.patch("funcx_web_service.routes.funcx.ingest_function")
     result = flask_test_client.post(
         "api/v1/functions",
@@ -35,7 +35,7 @@ def test_register_function(flask_test_client, mock_auth_client, mocker):
     assert mock_ingest.call_args[0][2] == "123-456"
 
 
-def test_register_function_no_search(flask_test_client, mock_auth_client, mocker):
+def test_register_function_no_search(flask_test_client, in_mock_auth_state, mocker):
     mock_ingest = mocker.patch("funcx_web_service.routes.funcx.ingest_function")
     mock_user = User(id=42, username="bob")
 
@@ -58,7 +58,9 @@ def test_register_function_no_search(flask_test_client, mock_auth_client, mocker
     assert mock_ingest.not_called
 
 
-def test_register_function_with_container(flask_test_client, mock_auth_client, mocker):
+def test_register_function_with_container(
+    flask_test_client, in_mock_auth_state, mocker
+):
     mock_ingest = mocker.patch("funcx_web_service.routes.funcx.ingest_function")
     mock_user = User(id=42, username="bob")
     mocker.patch.object(User, "find_by_username", return_value=mock_user)
@@ -91,7 +93,9 @@ def test_register_function_with_container(flask_test_client, mock_auth_client, m
     assert saved_function.container.container_id == 44
 
 
-def test_register_function_with_group_auth(flask_test_client, mock_auth_client, mocker):
+def test_register_function_with_group_auth(
+    flask_test_client, in_mock_auth_state, mocker
+):
     mock_ingest = mocker.patch("funcx_web_service.routes.funcx.ingest_function")
     mock_user = User(id=42, username="bob")
     mocker.patch.object(User, "find_by_username", return_value=mock_user)
@@ -127,7 +131,7 @@ def test_register_function_with_group_auth(flask_test_client, mock_auth_client, 
     assert saved_function.auth_groups[0].id == 45
 
 
-def test_update_function(flask_test_client, mock_auth_client, mocker):
+def test_update_function(flask_test_client, in_mock_auth_state, mocker):
     mock_update = mocker.patch(
         "funcx_web_service.routes.funcx.update_function", return_value=302
     )
@@ -154,7 +158,7 @@ def test_update_function(flask_test_client, mock_auth_client, mocker):
     )
 
 
-def test_delete_function(flask_test_client, mock_auth_client, mock_user, mocker):
+def test_delete_function(flask_test_client, in_mock_auth_state, mock_user, mocker):
     mock_delete = mocker.patch(
         "funcx_web_service.routes.funcx.delete_function", return_value=302
     )

--- a/tests/unit/routes/test_status.py
+++ b/tests/unit/routes/test_status.py
@@ -5,7 +5,7 @@ from funcx_web_service.models.user import User
 
 
 def test_get_status(
-    flask_test_client, mock_auth_client, mock_redis_task_factory, mock_user: User
+    flask_test_client, in_mock_auth_state, mock_redis_task_factory, mock_user: User
 ):
     mock_redis_task_factory("42")
     result = flask_test_client.get(
@@ -16,7 +16,7 @@ def test_get_status(
 
 
 def test_unauthorized_get_status(
-    flask_test_client, mock_auth_client, mock_redis_task_factory, mock_user: User
+    flask_test_client, in_mock_auth_state, mock_redis_task_factory, mock_user: User
 ):
     """
     Verify that a user cannot retrieve a Task status which is not theirs
@@ -31,7 +31,7 @@ def test_unauthorized_get_status(
 
 def test_get_batch_status(
     flask_test_client,
-    mock_auth_client,
+    in_mock_auth_state,
     mock_redis,
     mock_redis_task_factory,
     mock_user: User,
@@ -58,7 +58,7 @@ def test_get_batch_status(
 
 
 def test_unauthorized_get_batch_status(
-    flask_test_client, mocker, mock_auth_client, mock_redis_task_factory, mock_redis
+    flask_test_client, mocker, in_mock_auth_state, mock_redis_task_factory, mock_redis
 ):
     """
     Verify that a user cannot retrieve a status for a Batch which is not theirs

--- a/tests/unit/routes/test_submit_function.py
+++ b/tests/unit/routes/test_submit_function.py
@@ -3,7 +3,9 @@ from funcx_common.response_errors import ResponseErrorCode
 from funcx_web_service.models.tasks import TaskGroup
 
 
-def test_submit_function_access_forbidden(flask_test_client, mocker, mock_auth_client):
+def test_submit_function_access_forbidden(
+    flask_test_client, mocker, in_mock_auth_state
+):
     mock_authorize_function = mocker.patch(
         "funcx_web_service.routes.funcx.authorize_function", return_value=False
     )
@@ -26,7 +28,7 @@ def test_submit_function_access_forbidden(flask_test_client, mocker, mock_auth_c
     assert res["reason"] == "Unauthorized access to function 1111"
 
 
-def test_submit_function_not_found(flask_test_client, mocker, mock_auth_client):
+def test_submit_function_not_found(flask_test_client, mocker, in_mock_auth_state):
 
     mock_find_function = mocker.patch(
         "funcx_web_service.authentication.auth.Function.find_by_uuid",
@@ -51,7 +53,9 @@ def test_submit_function_not_found(flask_test_client, mocker, mock_auth_client):
     assert res["reason"] == "Function 1111 could not be resolved"
 
 
-def test_submit_endpoint_access_forbidden(flask_test_client, mocker, mock_auth_client):
+def test_submit_endpoint_access_forbidden(
+    flask_test_client, mocker, in_mock_auth_state
+):
     mock_authorize_function = mocker.patch(
         "funcx_web_service.routes.funcx.authorize_function", return_value=True
     )
@@ -85,7 +89,7 @@ def test_submit_endpoint_access_forbidden(flask_test_client, mocker, mock_auth_c
     assert res["reason"] == "Unauthorized access to endpoint 2222"
 
 
-def test_submit_endpoint_not_found(flask_test_client, mocker, mock_auth_client):
+def test_submit_endpoint_not_found(flask_test_client, mocker, in_mock_auth_state):
     mock_authorize_function = mocker.patch(
         "funcx_web_service.routes.funcx.authorize_function", return_value=True
     )
@@ -121,7 +125,7 @@ def test_submit_endpoint_not_found(flask_test_client, mocker, mock_auth_client):
 
 
 def test_submit_function_not_permitted(
-    flask_test_client, mocker, mock_auth_client, mock_endpoint
+    flask_test_client, mocker, in_mock_auth_state, mock_endpoint
 ):
     mock_authorize_function = mocker.patch(
         "funcx_web_service.routes.funcx.authorize_function", return_value=True
@@ -158,7 +162,7 @@ def test_submit_function_not_permitted(
 
 
 def test_submit_function(
-    flask_test_client, mocker, mock_auth_client, mock_redis_pubsub, mock_redis
+    flask_test_client, mocker, in_mock_auth_state, mock_redis_pubsub, mock_redis
 ):
     mock_function_auth = mocker.patch(
         "funcx_web_service.routes.funcx.authorize_function", return_value=True

--- a/tests/unit/routes/test_task_groups.py
+++ b/tests/unit/routes/test_task_groups.py
@@ -2,7 +2,7 @@ from funcx_web_service.models.tasks import TaskGroup
 
 
 def test_get_batch_info(
-    flask_test_client, mocker, mock_user, mock_auth_client, mock_redis
+    flask_test_client, mocker, mock_user, in_mock_auth_state, mock_redis
 ):
     TaskGroup(mock_redis, "123", user_id=mock_user.id)
     exists_spy = mocker.spy(TaskGroup, "exists")


### PR DESCRIPTION
~This work is based off of #270 . It shows some of the direction in which I'm trying to take the testsuite, and the codebase in general. It therefore may have bearing on review of #270 but is submitted for now as a draft.~

EDIT: now ready for review.

---

The AuthenticationState or AuthState is a pattern in use in several Globus services at this point. It's sufficiently well-established that we have considered library-izing it as part of the globus-sdk. (We have not done so because it tends to rely on too many application-specific details, and a generalized form of it is therefore hard to make useable.)

The idea is to take the authentication callout on a bearer token (introspect), and wrap up the result in a dedicated object stored in the threadlocal `flask.g`. This allows for a few important bits of value.

- Any part of the application can access authentication info via `flask.g` (not explored in this PR).
- The interface for Globus Auth is now encapsulated in a dedicated abstraction, allowing for clear mocks in the testsuite.
- Other services (e.g. Globus Groups) can be covered under this abstraction as well, adding them to the easily-mockable context for the application (not done in this PR; saved for future work).
- There is a well-defined object to test in order to test auth interactions. e.g. If we want to check application behavior if introspect returns a 500-class error, we can write tests for the AuthenticationState.