### PR TITLE
Add tests for redis TaskGroup create, delete

### DIFF
--- a/funcx_web_service/models/tasks.py
+++ b/funcx_web_service/models/tasks.py
@@ -130,9 +130,9 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
         self.redis_client.delete(self.hname)
 
     @classmethod
-    def exists(cls, redis_client: Redis, task_id: str):
+    def exists(cls, redis_client: Redis, task_id: str) -> bool:
         """Check if a given task_id exists in Redis"""
-        return redis_client.exists(f"task_{task_id}")
+        return bool(redis_client.exists(f"task_{task_id}"))
 
 
 class TaskGroup(metaclass=HasRedisFieldsMeta):
@@ -174,6 +174,6 @@ class TaskGroup(metaclass=HasRedisFieldsMeta):
         self.redis_client.delete(self.hname)
 
     @classmethod
-    def exists(cls, redis_client: Redis, task_group_id: str):
+    def exists(cls, redis_client: Redis, task_group_id: str) -> bool:
         """Check if a given task_group_id exists in Redis"""
-        return redis_client.exists(f"task_group_{task_group_id}")
+        return bool(redis_client.exists(f"task_group_{task_group_id}"))

--- a/tests/unit/test_task_behavior.py
+++ b/tests/unit/test_task_behavior.py
@@ -2,7 +2,7 @@ import uuid
 
 from funcx_common.tasks import TaskState
 
-from funcx_web_service.models.tasks import InternalTaskState, RedisTask
+from funcx_web_service.models.tasks import InternalTaskState, RedisTask, TaskGroup
 
 
 def test_redis_task_creation(mock_redis):
@@ -30,3 +30,53 @@ def test_redis_task_double_lookup(mock_redis):
     second_task = RedisTask(mock_redis, task_id)
     assert second_task.status == TaskState.SUCCESS
     assert second_task.internal_status == InternalTaskState.COMPLETE
+
+
+def test_redis_task_delete(mock_redis):
+    task_id = str(uuid.uuid1())
+
+    assert not RedisTask.exists(mock_redis, task_id)
+    task = RedisTask(mock_redis, task_id)
+
+    assert RedisTask.exists(mock_redis, task_id)
+    task.delete()
+
+    assert not RedisTask.exists(mock_redis, task_id)
+
+
+def test_task_group_create(mock_redis):
+    task_group_id = str(uuid.uuid1())
+    user_id = 101
+
+    assert not TaskGroup.exists(mock_redis, task_group_id)
+
+    tg = TaskGroup(mock_redis, task_group_id, user_id=user_id)
+    assert tg.user_id == user_id
+
+    assert TaskGroup.exists(mock_redis, task_group_id)
+
+
+def test_task_group_delete(mock_redis):
+    task_group_id = str(uuid.uuid1())
+    user_id = 101
+
+    assert not TaskGroup.exists(mock_redis, task_group_id)
+    tg = TaskGroup(mock_redis, task_group_id, user_id=user_id)
+    assert TaskGroup.exists(mock_redis, task_group_id)
+    tg.delete()
+    assert not TaskGroup.exists(mock_redis, task_group_id)
+
+
+def test_task_group_no_user_id(mock_redis):
+    # creating a TaskGroup without setting user_id results in no creation within redis,
+    # and the TaskGroup does not exist
+    # TODO: determine if this is the desired behavior
+    # maybe __init__ should raise an exception if `user_id` is not set?
+    task_group_id = str(uuid.uuid1())
+
+    assert not TaskGroup.exists(mock_redis, task_group_id)
+
+    tg = TaskGroup(mock_redis, task_group_id)
+    assert tg.user_id is None
+
+    assert not TaskGroup.exists(mock_redis, task_group_id)


### PR DESCRIPTION
Also fix an issue where `exists()` was returning an int, when a bool is expected by surrounding code. `bool(exists(...))` solves this. Type annotate `exists()` on RedisTask and TaskGroup to indicate the expected return type.

Testing revealed odd (possibly unexpected) semantics for TaskGroup when `user_id` is not set. There is now a test which demonstrates and explains the behavior, but it also includes a TODO comment for evaluating and considering changing it.

---

This takes us up to 100% line coverage on `funcx_web_service/models/tasks.py`, which makes the coverage report shorter and will help us zero-in on other areas of testing improvement.