### PR TITLE
Add initial, minimal mypy config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Install tox
       run: python -m pip install tox
     - name: Lint
-      run: python -m tox -e lint
+      run: python -m tox -e lint,mypy
     - name: Safety Check
       run: python -m tox -e safety
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: lint
 lint:
-	tox -e lint
+	tox -e lint,mypy
 
 .PHONY: test
 test:

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -1,5 +1,6 @@
 import json
 import time
+import typing as t
 import uuid
 
 import requests
@@ -250,7 +251,11 @@ def submit(user: User):
             raise TaskGroupAccessForbidden(task_group_id)
 
     # this is a breaking change for old funcx sdk versions
-    results = {"response": "batch", "task_group_id": task_group_id, "results": []}
+    results: t.Dict[str, t.Any] = {
+        "response": "batch",
+        "task_group_id": task_group_id,
+        "results": [],
+    }
 
     final_http_status = 200
     success_count = 0
@@ -704,26 +709,42 @@ def get_ep_stats(user: User, endpoint_id):
 
     rc = g_redis_client()
 
-    status = {"status": "offline", "logs": []}
+    status: str = "offline"
+    status_logs: t.List[t.Dict[str, t.Any]] = []
     try:
         end = min(rc.llen(f"ep_status_{endpoint_id}"), last)
         print("Total len :", end)
         items = rc.lrange(f"ep_status_{endpoint_id}", 0, end)
         if items:
             for i in items:
-                status["logs"].append(json.loads(i))
+                dataitem = json.loads(i)
+                if not isinstance(dataitem, dict):
+                    raise EndpointStatsError(
+                        endpoint_id, "endpoint stats failed to load, nondict data"
+                    )
+                status_logs.append(dataitem)
 
             # timestamp is an epoch timestamp
-            logs = status["logs"]  # should have been json loaded already
-            newest_timestamp = logs[0]["timestamp"]
+            newest_timestamp = status_logs[0].get("timestamp")
+            if newest_timestamp is None or (
+                not isinstance(newest_timestamp, (int, float))
+            ):
+                raise EndpointStatsError(
+                    endpoint_id, "could not load latest timestamp from ep status info"
+                )
+
             now = time.time()
             if now - newest_timestamp < alive_threshold:
-                status["status"] = "online"
+                status = "online"
 
+    # FIXME: identify error conditions and remove this blanket error capture
     except Exception as e:
+        if isinstance(e, EndpointStatsError):
+            raise
         raise EndpointStatsError(endpoint_id, str(e))
 
-    return jsonify(status)
+    status_info = {"logs": status_logs, "status": status}
+    return jsonify(status_info)
 
 
 @funcx_api.route("/endpoints/<endpoint_id>", methods=["DELETE"])
@@ -897,9 +918,12 @@ def reg_function(user: User, user_uuid):
         raise RequestKeyError(str(key_error))
 
     except Exception as e:
+        function_name = (
+            function_rec.function_name if function_rec is not None else "<nullfunc>"
+        )
         message = (
-            f"Function registration failed for user:{user.username} "
-            f"function_name:{function_rec.function_name} due to {e}"
+            f"Function registration failed for user={user.username} , "
+            f"function_name={function_name} due to {e}"
         )
         app.logger.error(message)
         raise InternalError(message)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+ignore_missing_imports = true
+# desired conf (do not set yet):
+#
+# strict = true
+# warn_unreachable = true
+# warn_no_return = true

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,13 @@ deps = pre-commit<3
 skip_install = true
 commands = pre-commit run --all-files
 
+[testenv:mypy]
+deps =
+    mypy
+    types-requests
+    types-redis
+commands = mypy funcx_web_service/
+
 [testenv:safety]
 skip_install = true
 deps =


### PR DESCRIPTION
Setup mypy as a tox target, add it to `make lint` and CI.
Configure mypy to be relatively non-strict. Many functions will not be type-checked because they have no annotations, and several useful mypy warning modes are not enabled.

This still flags several issues, in code that is not type-safe and which has annotated signature lines. Resolve these issues with as few changes as possible.

---

This kind of config basically means
"If you have type annotations, we will check that they are correct."