### PR TITLE
Add container service adaptor

### DIFF
--- a/conf/app.conf.template
+++ b/conf/app.conf.template
@@ -3,3 +3,8 @@ REDIS_HOST = "localhost"
 
 GLOBUS_CLIENT = <<Globus Client ID>>
 GLOBUS_KEY = <<Globus Secret Key>>
+
+CONTAINER_SERVICE_ENABLED = False
+
+# URL of Container Service
+CONTAINER_SERVICE = http://localhost:5001

--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -6,6 +6,7 @@ from flask import Flask, request
 from flask.logging import default_handler
 from pythonjsonlogger import jsonlogger
 
+from funcx_web_service.container_service_adapter import ContainerServiceAdapter
 from funcx_web_service.error_responses import create_error_response
 from funcx_web_service.response import FuncxResponse
 from funcx_web_service.routes.funcx import funcx_api
@@ -57,6 +58,17 @@ def create_app(test_config=None):
     else:
         application.config.from_envvar("APP_CONFIG_FILE")
         application.config.update(_override_config_with_environ(application))
+
+    if not hasattr(application, "extensions"):
+        application.extensions = {}
+
+    if application.config.get("CONTAINER_SERVICE_ENABLED", False):
+        container_service = ContainerServiceAdapter(
+            application.config["CONTAINER_SERVICE"]
+        )
+        application.extensions["ContainerService"] = container_service
+    else:
+        application.extensions["ContainerService"] = None
 
     # 100,000 Bytes is the max content length we will log for request/response JSON
     # due to the CloudWatch max log size

--- a/funcx_web_service/container_service_adapter.py
+++ b/funcx_web_service/container_service_adapter.py
@@ -1,0 +1,15 @@
+from urllib.parse import urljoin
+
+import requests
+
+
+class ContainerServiceAdapter:
+    def __init__(self, service_url):
+        self.service_url = service_url
+
+    def get_version(self):
+        result = requests.get(urljoin(self.service_url, "version"))
+        if result.status_code == 200:
+            return result.json()
+        else:
+            return {"version": "Service Unavailable"}

--- a/funcx_web_service/routes/funcx.py
+++ b/funcx_web_service/routes/funcx.py
@@ -575,14 +575,18 @@ def get_version():
         return jsonify(forwarder_version)
 
     if s == "all":
-        return jsonify(
-            {
-                "api": VERSION,
-                "forwarder": forwarder_version,
-                "min_sdk_version": MIN_SDK_VERSION,
-                "min_ep_version": min_ep_version,
-            }
-        )
+        result = {
+            "api": VERSION,
+            "forwarder": forwarder_version,
+            "min_sdk_version": MIN_SDK_VERSION,
+            "min_ep_version": min_ep_version,
+        }
+
+        if app.extensions["ContainerService"]:
+            result["container_service"] = app.extensions[
+                "ContainerService"
+            ].get_version()["version"]
+        return jsonify(result)
 
     raise RequestMalformed("unknown service type or other error.")
 

--- a/tests/routes/app_test_base.py
+++ b/tests/routes/app_test_base.py
@@ -2,18 +2,20 @@ from funcx_web_service import create_app
 
 
 class AppTestBase:
-    def test_client(self):
-        app = create_app(
-            test_config={
-                "REDIS_HOST": "localhost",
-                "REDIS_PORT": 5000,
-                "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-                "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-                "HOSTNAME": "http://testhost",
-                "FORWARDER_IP": "192.162.3.5",
-                "ADVERTISED_REDIS_HOST": "my-redis.com",
-            }
-        )
+    def test_client(self, extra_config=None):
+        test_config = {
+            "REDIS_HOST": "localhost",
+            "REDIS_PORT": 5000,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+            "HOSTNAME": "http://testhost",
+            "FORWARDER_IP": "192.162.3.5",
+            "ADVERTISED_REDIS_HOST": "my-redis.com",
+            "CONTAINER_SERVICE_ENABLED": False,
+        }
+
+        test_config.update(extra_config if extra_config else {})
+        app = create_app(test_config=test_config)
         app.secret_key = "Shhhhh"
         return app.test_client()
 

--- a/tests/test.config
+++ b/tests/test.config
@@ -1,3 +1,4 @@
 FOO = "bar"
 SECRET_VALUE = "blah"
 BOOL_VALUE = False
+CONTAINER_SERVICE_ENABLED = False

--- a/tests/test_container_service_adapter.py
+++ b/tests/test_container_service_adapter.py
@@ -1,0 +1,24 @@
+import responses
+
+from funcx_web_service import ContainerServiceAdapter
+
+
+class TestContainerServiceAdapter:
+    @responses.activate
+    def test_version(self):
+        responses.add(
+            responses.GET,
+            "http://container-service:5000/version",
+            json={"version": "3.14"},
+            status=200,
+        )
+        container_service = ContainerServiceAdapter("http://container-service:5000")
+        assert container_service.get_version() == {"version": "3.14"}
+
+    @responses.activate
+    def test_version_server_error(self):
+        responses.add(
+            responses.GET, "http://container-service:5000/version", status=500
+        )
+        container_service = ContainerServiceAdapter("http://container-service:5000")
+        assert container_service.get_version() == {"version": "Service Unavailable"}


### PR DESCRIPTION
# Problem
We need to connect the WebApp to the new Container Service, however the service is not ready to deploy so this needs to be switched off in production via a feature flag.

# Approach
* Created a ContainerServiceAdaptor
* Added new config options. If `CONTAINER_SERVICE_ENABLED` is included and set to True then we create a ContainerServiceAdaptor and connect it
* Added an optional check for ContiainerService version as part of the `version` route
