### PR TITLE
Move container routes to their own python file

### DIFF
--- a/funcx_web_service/__init__.py
+++ b/funcx_web_service/__init__.py
@@ -8,6 +8,7 @@ from pythonjsonlogger import jsonlogger
 
 from funcx_web_service.error_responses import create_error_response
 from funcx_web_service.response import FuncxResponse
+from funcx_web_service.routes.container import container_api
 from funcx_web_service.routes.funcx import funcx_api
 
 
@@ -157,6 +158,7 @@ def create_app(test_config=None):
 
     # Include the API blueprint
     application.register_blueprint(funcx_api, url_prefix="/v2")
+    application.register_blueprint(container_api, url_prefix="/v2")
     # Keeping these routes for backwards compatibility on tests.
     application.register_blueprint(funcx_api, url_prefix="/v1")
     application.register_blueprint(funcx_api, url_prefix="/api/v1")

--- a/funcx_web_service/routes/container.py
+++ b/funcx_web_service/routes/container.py
@@ -1,0 +1,89 @@
+import uuid
+
+from flask import Blueprint
+from flask import current_app as app
+from flask import jsonify, request
+from funcx_common.response_errors import InternalError, RequestKeyError
+
+from funcx_web_service.authentication.auth import authenticated
+
+from ..models.container import Container, ContainerImage
+from ..models.user import User
+
+container_api = Blueprint("container_routes", __name__)
+
+
+@container_api.route("/containers/<container_id>/<container_type>", methods=["GET"])
+@authenticated
+def get_cont(user: User, container_id, container_type):
+    """Get the details of a container.
+
+    Parameters
+    ----------
+    user : User
+        The primary identity of the user
+    container_id : str
+        The id of the container
+    container_type : str
+        The type of containers to return: Docker, Singularity, Shifter, etc.
+
+    Returns
+    -------
+    dict
+        A dictionary of container details
+    """
+
+    app.logger.info(f"Getting container details: {container_id}")
+    container = Container.find_by_uuid_and_type(container_id, container_type)
+    app.logger.info(f"Got container: {container}")
+    return jsonify({"container": container.to_json()})
+
+
+@container_api.route("/containers", methods=["POST"])
+@authenticated
+def reg_container(user: User):
+    """Register a new container.
+
+    Parameters
+    ----------
+    user : User
+        The primary identity of the user
+
+    JSON Body
+    ---------
+        name: Str
+        description: Str
+        type: The type of containers that will be used (Singularity, Shifter, Docker)
+        location:  The location of the container (e.g., its docker url).
+
+    Returns
+    -------
+    dict
+        A dictionary of container details including its uuid
+    """
+
+    app.logger.debug("Creating container.")
+    post_req = request.json
+
+    try:
+        container_rec = Container(
+            author=user.id,
+            name=post_req["name"],
+            description=None
+            if not post_req["description"]
+            else post_req["description"],
+            container_uuid=str(uuid.uuid4()),
+        )
+        container_rec.images = [
+            ContainerImage(type=post_req["type"], location=post_req["location"])
+        ]
+
+        container_rec.save_to_db()
+
+        app.logger.info(f"Created container: {container_rec.container_uuid}")
+        return jsonify({"container_id": container_rec.container_uuid})
+    except KeyError as e:
+        raise RequestKeyError(str(e))
+
+    except Exception as e:
+        raise InternalError(f"error adding container - {e}")

--- a/tests/routes/test_register_container.py
+++ b/tests/routes/test_register_container.py
@@ -8,7 +8,7 @@ class TestRegisterContainer(AppTestBase):
     def test_register_container(self, mocker, mock_auth_client):
         client = self.client
         result = client.post(
-            "api/v1/containers",
+            "v2/containers",
             json={
                 "name": "myContainer",
                 "function_name": "test fun",
@@ -36,7 +36,7 @@ class TestRegisterContainer(AppTestBase):
     def test_register_container_invalid_spec(self, mocker, mock_auth_client):
         client = self.client
         result = client.post(
-            "api/v1/containers",
+            "v2/containers",
             json={
                 "type": "docker",
                 "location": "http://hub.docker.com/myContainer",
@@ -58,7 +58,7 @@ class TestRegisterContainer(AppTestBase):
 
         client = self.client
         result = client.get(
-            "api/v1/containers/1/docker", headers={"Authorization": "my_token"}
+            "v2/containers/1/docker", headers={"Authorization": "my_token"}
         )
 
         result_container = result.json["container"]


### PR DESCRIPTION
# Problem
The `routes/funcx.py` is too large and we need to add some new routes for the container service

# Approach
Created a new python file in the `routes` module for container routes.

Registered that as separate Blueprint

Updated the tests since we really should only be using the new `/v2` URLs 