### PR TITLE
set pool_pre_ping to True for sqlalchemy

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -72,6 +72,7 @@ def run_migrations_online():
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        pool_pre_ping=True,
     )
 
     with connectable.connect() as connection:


### PR DESCRIPTION
pre-ping to check connections for liveness on checkout, avoiding a web service error for the next request that uses a broken connection

See: https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping